### PR TITLE
SharpNeatConsole - Fixed offset used in loadseed

### DIFF
--- a/src/SharpNeatConsole/Program.cs
+++ b/src/SharpNeatConsole/Program.cs
@@ -126,8 +126,8 @@ namespace SharpNeatConsole
                             }
 
                             int populationSize;
-                            if(!int.TryParse(cmdArgs[1], out populationSize)) {
-                                Console.WriteLine($"Error. Invalid [size] argument [{cmdArgs[1]}].");
+                            if(!int.TryParse(cmdArgs[2], out populationSize)) {
+                                Console.WriteLine($"Error. Invalid [size] argument [{cmdArgs[2]}].");
                                 break;
                             }
 


### PR DESCRIPTION
Wrong offset used resulted in parsing the filename instead of population size