### PR TITLE
Generic phenome evaluators

### DIFF
--- a/src/Benchmarks/SharpNeat.Tasks.Benchmarks/BinaryMultiplexer/BinaryElevenMultiplexerEvaluatorBenchmarks.cs
+++ b/src/Benchmarks/SharpNeat.Tasks.Benchmarks/BinaryMultiplexer/BinaryElevenMultiplexerEvaluatorBenchmarks.cs
@@ -7,7 +7,7 @@ namespace SharpNeat.Tasks.BinaryMultiplexer;
 
 public class BinaryElevenMultiplexerEvaluatorBenchmarks
 {
-    static readonly BinaryElevenMultiplexerEvaluator __evaluator = new();
+    static readonly BinaryElevenMultiplexerEvaluatorDouble __evaluator = new();
     static readonly NullBlackBox __blackBox = new();
 
     [Benchmark]

--- a/src/Benchmarks/SharpNeat.Tasks.Benchmarks/BinaryMultiplexer/BinarySixMultiplexerEvaluatorBenchmarks.cs
+++ b/src/Benchmarks/SharpNeat.Tasks.Benchmarks/BinaryMultiplexer/BinarySixMultiplexerEvaluatorBenchmarks.cs
@@ -7,7 +7,7 @@ namespace SharpNeat.Tasks.BinaryMultiplexer;
 
 public class BinarySixMultiplexerEvaluatorBenchmarks
 {
-    static readonly BinarySixMultiplexerEvaluator __evaluator = new();
+    static readonly BinarySixMultiplexerEvaluatorDouble __evaluator = new();
     static readonly NullBlackBox __blackBox = new();
 
     [Benchmark]

--- a/src/Benchmarks/SharpNeat.Tasks.Benchmarks/BinaryMultiplexer/BinaryTwentyMultiplexerEvaluatorBenchmarks.cs
+++ b/src/Benchmarks/SharpNeat.Tasks.Benchmarks/BinaryMultiplexer/BinaryTwentyMultiplexerEvaluatorBenchmarks.cs
@@ -7,7 +7,7 @@ namespace SharpNeat.Tasks.BinaryMultiplexer;
 
 public class BinaryTwentyMultiplexerEvaluatorBenchmarks
 {
-    static readonly BinaryTwentyMultiplexerEvaluator __evaluator = new();
+    static readonly BinaryTwentyMultiplexerEvaluatorDouble __evaluator = new();
     static readonly NullBlackBox __blackBox = new();
 
     [Benchmark]

--- a/src/Benchmarks/SharpNeat.Tasks.Benchmarks/FunctionRegression/FuncRegressionUtilsBenchmarks.cs
+++ b/src/Benchmarks/SharpNeat.Tasks.Benchmarks/FunctionRegression/FuncRegressionUtilsBenchmarks.cs
@@ -7,7 +7,7 @@ public class FuncRegressionUtilsBenchmarks
     #region Instance Fields
 
     const int __sampleCount = 100;
-    readonly ParamSamplingInfo _paramSamplingInfo = new(0, 2 * Math.PI, __sampleCount);
+    readonly ParamSamplingInfo<double> _paramSamplingInfo = new(0, 2 * Math.PI, __sampleCount);
     readonly double[] _yArr = new double[__sampleCount];
     readonly double[] _gradientArr = new double[__sampleCount];
 
@@ -17,8 +17,8 @@ public class FuncRegressionUtilsBenchmarks
 
     public FuncRegressionUtilsBenchmarks()
     {
-        var psi = new ParamSamplingInfo(0, 2 * Math.PI, __sampleCount);
-        FuncRegressionUtils.Probe((x) => Math.Sin(x), psi, _yArr);
+        var psi = new ParamSamplingInfo<double>(0, 2 * MathF.PI, __sampleCount);
+        FuncRegressionUtils<double>.Probe((x) => Math.Sin(x), psi, _yArr);
     }
 
     #endregion
@@ -28,7 +28,7 @@ public class FuncRegressionUtilsBenchmarks
     [Benchmark]
     public void CalcGradients()
     {
-        FuncRegressionUtils.CalcGradients(_paramSamplingInfo, _yArr, _gradientArr);
+        FuncRegressionUtils<double>.CalcGradients(_paramSamplingInfo, _yArr, _gradientArr);
     }
 
     #endregion

--- a/src/Benchmarks/SharpNeat.Tasks.Benchmarks/PreyCapture/PreyCaptureWorldBenchmark.cs
+++ b/src/Benchmarks/SharpNeat.Tasks.Benchmarks/PreyCapture/PreyCaptureWorldBenchmark.cs
@@ -4,12 +4,12 @@ namespace SharpNeat.Tasks.PreyCapture;
 
 public class PreyCaptureWorldBenchmark : IDisposable
 {
-    readonly PreyCaptureWorld _world;
+    readonly PreyCaptureWorld<double> _world;
     readonly MockPreyCaptureAgent _agent;
 
     public PreyCaptureWorldBenchmark()
     {
-        _world = new PreyCaptureWorld(4, 1f, 4f, 1000);
+        _world = new PreyCaptureWorld<double>(4, 1f, 4f, 1000);
         _agent = new MockPreyCaptureAgent();
     }
 

--- a/src/SharpNeat.Tasks.Windows/FunctionRegression/FnRegressionControl.cs
+++ b/src/SharpNeat.Tasks.Windows/FunctionRegression/FnRegressionControl.cs
@@ -16,7 +16,7 @@ namespace SharpNeat.Domains.FunctionRegression;
 public partial class FnRegressionControl : GenomeControl
 {
     readonly Func<double,double> _fn;
-    readonly IBlackBoxProbe _blackBoxProbe;
+    readonly IBlackBoxProbe<double> _blackBoxProbe;
     readonly double[] _yArrTarget;
     readonly IGenomeDecoder<NeatGenome<double>,IBlackBox<double>> _genomeDecoder;
     readonly PointPairList _pplTarget;
@@ -31,7 +31,7 @@ public partial class FnRegressionControl : GenomeControl
     /// <param name="genomeDecoder">Genome decoder.</param>
     public FnRegressionControl(
         Func<double,double> fn,
-        ParamSamplingInfo paramSamplingInfo,
+        ParamSamplingInfo<double> paramSamplingInfo,
         bool generativeMode,
         IGenomeDecoder<NeatGenome<double>,IBlackBox<double>> genomeDecoder)
     {
@@ -44,20 +44,20 @@ public partial class FnRegressionControl : GenomeControl
         // Determine the mid output value of the function (over the specified sample points) and a scaling factor
         // to apply the to neural network response for it to be able to recreate the function (because the neural net
         // output range is typically in the interval [0,1], e.g. when using the logistic function activation function).
-        FuncRegressionUtils.CalcFunctionMidAndScale(
+        FuncRegressionUtils<double>.CalcFunctionMidAndScale(
             fn, paramSamplingInfo,
             out double mid,
             out double scale);
 
         if(generativeMode)
         {
-            _blackBoxProbe = new GenerativeBlackBoxProbe(
+            _blackBoxProbe = new GenerativeBlackBoxProbe<double>(
                 paramSamplingInfo.SampleResolution,
                 mid, scale);
         }
         else
         {
-            _blackBoxProbe = new BlackBoxProbe(
+            _blackBoxProbe = new BlackBoxProbe<double>(
                 paramSamplingInfo, mid, scale);
         }
 

--- a/src/SharpNeat.Tasks.Windows/GenerativeFunctionRegression/GenerativeFnRegressionUi.cs
+++ b/src/SharpNeat.Tasks.Windows/GenerativeFunctionRegression/GenerativeFnRegressionUi.cs
@@ -13,12 +13,12 @@ public sealed class GenerativeFnRegressionUi : NeatExperimentUi
 {
     readonly INeatExperiment<double> _neatExperiment;
     readonly Func<double, double> _fn;
-    readonly ParamSamplingInfo _paramSamplingInfo;
+    readonly ParamSamplingInfo<double> _paramSamplingInfo;
 
     public GenerativeFnRegressionUi(
         INeatExperiment<double> neatExperiment,
         Func<double, double> fn,
-        ParamSamplingInfo paramSamplingInfo)
+        ParamSamplingInfo<double> paramSamplingInfo)
     {
         _neatExperiment = neatExperiment ?? throw new ArgumentNullException(nameof(neatExperiment));
         _fn = fn;

--- a/src/SharpNeat.Tasks.Windows/GenerativeFunctionRegression/GenerativeFnRegressionUiFactory.cs
+++ b/src/SharpNeat.Tasks.Windows/GenerativeFunctionRegression/GenerativeFnRegressionUiFactory.cs
@@ -27,7 +27,7 @@ public sealed class GenerativeFnRegressionUiFactory : IExperimentUiFactory
         ReadEvaluationSchemeConfig(
             experimentConfig.CustomEvaluationSchemeConfig,
             out Func<double, double> fn,
-            out ParamSamplingInfo paramSamplingInfo);
+            out ParamSamplingInfo<double> paramSamplingInfo);
 
         return new GenerativeFnRegressionUi(
             neatExperiment, fn, paramSamplingInfo);
@@ -36,7 +36,7 @@ public sealed class GenerativeFnRegressionUiFactory : IExperimentUiFactory
     private static void ReadEvaluationSchemeConfig(
         GenerativeFnRegressionCustomConfig customConfig,
         out Func<double, double> fn,
-        out ParamSamplingInfo paramSamplingInfo)
+        out ParamSamplingInfo<double> paramSamplingInfo)
     {
         // Read function ID.
         FunctionId functionId = Enum.Parse<FunctionId>(customConfig.FunctionId);
@@ -44,7 +44,7 @@ public sealed class GenerativeFnRegressionUiFactory : IExperimentUiFactory
         fn = FunctionFactory.GetFunction(functionId);
 
         // Read sample interval min and max, and sample resolution.
-        paramSamplingInfo = new ParamSamplingInfo(
+        paramSamplingInfo = new ParamSamplingInfo<double>(
             customConfig.SampleIntervalMin,
             customConfig.SampleIntervalMax,
             customConfig.SampleResolution);

--- a/src/SharpNeat.Tasks.Windows/PreyCapture/PreyCaptureControl.cs
+++ b/src/SharpNeat.Tasks.Windows/PreyCapture/PreyCaptureControl.cs
@@ -29,7 +29,7 @@ public class PreyCaptureControl : GenomeControl
     readonly Brush _brushPrey = new SolidBrush(Color.Green);
 
     readonly IGenomeDecoder<NeatGenome<double>,IBlackBox<double>> _genomeDecoder;
-    readonly PreyCaptureWorld _world;
+    readonly PreyCaptureWorld<double> _world;
 
     // The agent used by the simulation thread.
     volatile IBlackBox<double> _agent;
@@ -54,7 +54,7 @@ public class PreyCaptureControl : GenomeControl
     /// <param name="world">Prey capture world.</param>
     public PreyCaptureControl(
         IGenomeDecoder<NeatGenome<double>, IBlackBox<double>> genomeDecoder,
-        PreyCaptureWorld world)
+        PreyCaptureWorld<double> world)
     {
         _genomeDecoder = genomeDecoder ?? throw new ArgumentNullException(nameof(genomeDecoder));
         _world = world ?? throw new ArgumentNullException(nameof(world));

--- a/src/SharpNeat.Tasks.Windows/PreyCapture/PreyCaptureExperimentUi.cs
+++ b/src/SharpNeat.Tasks.Windows/PreyCapture/PreyCaptureExperimentUi.cs
@@ -28,7 +28,7 @@ public sealed class PreyCaptureExperimentUi : NeatExperimentUi
     /// <inheritdoc/>
     public override GenomeControl CreateTaskControl()
     {
-        PreyCaptureWorld world = new(
+        PreyCaptureWorld<double> world = new(
             _customConfig.PreyInitMoves,
             _customConfig.PreySpeed,
             _customConfig.SensorRange,

--- a/src/SharpNeat.Tasks/BinaryElevenMultiplexer/BinaryElevenMultiplexerEvaluationScheme.cs
+++ b/src/SharpNeat.Tasks/BinaryElevenMultiplexer/BinaryElevenMultiplexerEvaluationScheme.cs
@@ -1,5 +1,6 @@
 ﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
+using System.Numerics;
 using SharpNeat.Evaluation;
 
 namespace SharpNeat.Tasks.BinaryElevenMultiplexer;
@@ -7,7 +8,9 @@ namespace SharpNeat.Tasks.BinaryElevenMultiplexer;
 /// <summary>
 /// Evaluation scheme for the Binary 11-Multiplexer task.
 /// </summary>
-public sealed class BinaryElevenMultiplexerEvaluationScheme : IBlackBoxEvaluationScheme<double>
+/// <typeparam name="TScalar">Black box input/output data type.</typeparam>
+public sealed class BinaryElevenMultiplexerEvaluationScheme<TScalar> : IBlackBoxEvaluationScheme<TScalar>
+    where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
 {
     /// <inheritdoc/>
     public int InputCount => 12;
@@ -28,9 +31,24 @@ public sealed class BinaryElevenMultiplexerEvaluationScheme : IBlackBoxEvaluatio
     public bool EvaluatorsHaveState => false;
 
     /// <inheritdoc/>
-    public IPhenomeEvaluator<IBlackBox<double>> CreateEvaluator()
+    public IPhenomeEvaluator<IBlackBox<TScalar>> CreateEvaluator()
     {
-        return new BinaryElevenMultiplexerEvaluator();
+#pragma warning disable CS8603 // Possible null reference return.
+        Type scalarType = typeof(TScalar);
+
+        if(scalarType == typeof(double))
+        {
+            return new BinaryElevenMultiplexerEvaluatorDouble() as IPhenomeEvaluator<IBlackBox<TScalar>>;
+        }
+        else if(scalarType == typeof(float))
+        {
+            return new BinaryElevenMultiplexerEvaluatorFloat() as IPhenomeEvaluator<IBlackBox<TScalar>>;
+        }
+        else
+        {
+            throw new InvalidOperationException($"Unsupported scalar type '{scalarType}'.");
+        }
+#pragma warning restore CS8603 // Possible null reference return.
     }
 
     /// <inheritdoc/>

--- a/src/SharpNeat.Tasks/BinaryElevenMultiplexer/BinaryElevenMultiplexerEvaluatorDouble.cs
+++ b/src/SharpNeat.Tasks/BinaryElevenMultiplexer/BinaryElevenMultiplexerEvaluatorDouble.cs
@@ -1,0 +1,93 @@
+﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
+// See LICENSE.txt for details.
+using System.Diagnostics;
+using SharpNeat.Evaluation;
+
+namespace SharpNeat.Tasks.BinaryElevenMultiplexer;
+
+// TODO: Consider a variant on this evaluator that uses two outputs instead of one, i.e. 'false' and 'true' outputs;
+// (if both outputs are low or high then that's just an invalid response).
+
+/// <summary>
+/// Evaluator for the Binary 11-Multiplexer task.
+///
+/// Three inputs supply a binary number between 0 and 7; this number selects one of the
+/// further 8 inputs (eleven inputs in total). The correct response is the selected input's
+/// input signal (0 or 1).
+///
+/// Evaluation consists of querying the provided black box for all possible input combinations (2^11 = 2048).
+/// </summary>
+public sealed class BinaryElevenMultiplexerEvaluatorDouble : IPhenomeEvaluator<IBlackBox<double>>
+{
+    /// <summary>
+    /// Evaluate the provided black box against the Binary 11-Multiplexer task,
+    /// and return its fitness score.
+    /// </summary>
+    /// <param name="box">The black box to evaluate.</param>
+    /// <returns>A new instance of <see cref="FitnessInfo"/>.</returns>
+    public FitnessInfo Evaluate(IBlackBox<double> box)
+    {
+        double fitness = 0.0;
+        Span<double> inputs = box.Inputs.Span;
+        ref double output = ref box.Outputs.Span[0];
+
+        // 2048 test cases.
+        for(int i=0; i < 2048; i++)
+        {
+            // Bias input.
+            inputs[0] = 1.0;
+
+            // Apply bitmask to i and shift left to generate the input signals.
+            // Note. We could eliminate all the boolean logic by pre-building a table of test
+            // signals and correct responses.
+            inputs[1] = i & 0x1;
+            inputs[2] = (i>>1) & 0x1;
+            inputs[3] = (i>>2) & 0x1;
+            inputs[4] = (i>>3) & 0x1;
+            inputs[5] = (i>>4) & 0x1;
+            inputs[6] = (i>>5) & 0x1;
+            inputs[7] = (i>>6) & 0x1;
+            inputs[8] = (i>>7) & 0x1;
+            inputs[9] = (i>>8) & 0x1;
+            inputs[10] = (i>>9) & 0x1;
+            inputs[11] = (i>>10) & 0x1;
+
+            // Activate the black box.
+            box.Activate();
+
+            // Read output signal.
+            Clamp(ref output);
+            Debug.Assert(output >= 0.0, "Unexpected negative output.");
+
+            // Determine the correct answer with somewhat cryptic bit manipulation.
+            // The condition is true if the correct answer is true (1.0).
+            if(((1 << (3 + (i & 0x7))) &i) != 0)
+            {
+                // correct answer: true.
+                // Assign fitness on sliding scale between 0.0 and 1.0 based on squared error.
+                // In tests squared error drove evolution significantly more efficiently in this domain than absolute error.
+                // Note. To base fitness on absolute error use: fitness += output;
+                fitness += 1.0 - ((1.0 - output) * (1.0 - output));
+            }
+            else
+            {
+                // correct answer: false.
+                // Assign fitness on sliding scale between 0.0 and 1.0 based on squared error.
+                // In tests squared error drove evolution significantly more efficiently in this domain than absolute error.
+                // Note. To base fitness on absolute error use: fitness += 1.0-output;
+                fitness += 1.0 - (output * output);
+            }
+
+            // Reset black box ready for next test case.
+            box.Reset();
+        }
+
+        return new FitnessInfo(fitness);
+    }
+
+    private static void Clamp(ref double x)
+    {
+        if(x < 0.0) x = 0.0;
+        else if(x > 1.0) x = 1.0;
+    }
+}

--- a/src/SharpNeat.Tasks/BinaryElevenMultiplexer/BinaryElevenMultiplexerEvaluatorFloat.cs
+++ b/src/SharpNeat.Tasks/BinaryElevenMultiplexer/BinaryElevenMultiplexerEvaluatorFloat.cs
@@ -1,6 +1,5 @@
 ﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
-using System.Diagnostics;
 using SharpNeat.Evaluation;
 
 namespace SharpNeat.Tasks.BinaryElevenMultiplexer;
@@ -17,7 +16,7 @@ namespace SharpNeat.Tasks.BinaryElevenMultiplexer;
 ///
 /// Evaluation consists of querying the provided black box for all possible input combinations (2^11 = 2048).
 /// </summary>
-public sealed class BinaryElevenMultiplexerEvaluator : IPhenomeEvaluator<IBlackBox<double>>
+public sealed class BinaryElevenMultiplexerEvaluatorFloat : IPhenomeEvaluator<IBlackBox<float>>
 {
     /// <summary>
     /// Evaluate the provided black box against the Binary 11-Multiplexer task,
@@ -25,17 +24,17 @@ public sealed class BinaryElevenMultiplexerEvaluator : IPhenomeEvaluator<IBlackB
     /// </summary>
     /// <param name="box">The black box to evaluate.</param>
     /// <returns>A new instance of <see cref="FitnessInfo"/>.</returns>
-    public FitnessInfo Evaluate(IBlackBox<double> box)
+    public FitnessInfo Evaluate(IBlackBox<float> box)
     {
-        double fitness = 0.0;
-        Span<double> inputs = box.Inputs.Span;
-        ref double output = ref box.Outputs.Span[0];
+        float fitness = 0f;
+        Span<float> inputs = box.Inputs.Span;
+        ref float output = ref box.Outputs.Span[0];
 
         // 2048 test cases.
         for(int i=0; i < 2048; i++)
         {
             // Bias input.
-            inputs[0] = 1.0;
+            inputs[0] = 1f;
 
             // Apply bitmask to i and shift left to generate the input signals.
             // Note. We could eliminate all the boolean logic by pre-building a table of test
@@ -57,7 +56,6 @@ public sealed class BinaryElevenMultiplexerEvaluator : IPhenomeEvaluator<IBlackB
 
             // Read output signal.
             Clamp(ref output);
-            Debug.Assert(output >= 0.0, "Unexpected negative output.");
 
             // Determine the correct answer with somewhat cryptic bit manipulation.
             // The condition is true if the correct answer is true (1.0).
@@ -67,7 +65,7 @@ public sealed class BinaryElevenMultiplexerEvaluator : IPhenomeEvaluator<IBlackB
                 // Assign fitness on sliding scale between 0.0 and 1.0 based on squared error.
                 // In tests squared error drove evolution significantly more efficiently in this domain than absolute error.
                 // Note. To base fitness on absolute error use: fitness += output;
-                fitness += 1.0 - ((1.0 - output) * (1.0 - output));
+                fitness += 1f - ((1f - output) * (1f - output));
             }
             else
             {
@@ -75,7 +73,7 @@ public sealed class BinaryElevenMultiplexerEvaluator : IPhenomeEvaluator<IBlackB
                 // Assign fitness on sliding scale between 0.0 and 1.0 based on squared error.
                 // In tests squared error drove evolution significantly more efficiently in this domain than absolute error.
                 // Note. To base fitness on absolute error use: fitness += 1.0-output;
-                fitness += 1.0 - (output * output);
+                fitness += 1f - (output * output);
             }
 
             // Reset black box ready for next test case.
@@ -85,9 +83,9 @@ public sealed class BinaryElevenMultiplexerEvaluator : IPhenomeEvaluator<IBlackB
         return new FitnessInfo(fitness);
     }
 
-    private static void Clamp(ref double x)
+    private static void Clamp(ref float x)
     {
-        if(x < 0.0) x = 0.0;
-        else if(x > 1.0) x = 1.0;
+        if(x < 0.0) x = 0f;
+        else if(x > 1.0) x = 1f;
     }
 }

--- a/src/SharpNeat.Tasks/BinaryElevenMultiplexer/BinaryElevenMultiplexerExperimentFactory.cs
+++ b/src/SharpNeat.Tasks/BinaryElevenMultiplexer/BinaryElevenMultiplexerExperimentFactory.cs
@@ -22,7 +22,7 @@ public sealed class BinaryElevenMultiplexerExperimentFactory : INeatExperimentFa
         ExperimentConfig experimentConfig = JsonUtils.Deserialize<ExperimentConfig>(jsonConfigStream);
 
         // Create an evaluation scheme object for the binary 11-multiplexer task.
-        var evalScheme = new BinaryElevenMultiplexerEvaluationScheme();
+        var evalScheme = new BinaryElevenMultiplexerEvaluationScheme<double>();
 
         // Create a NeatExperiment object with the evaluation scheme,
         // and assign some default settings (these can be overridden by config).

--- a/src/SharpNeat.Tasks/BinarySixMultiplexer/BinarySixMultiplexerEvaluationScheme.cs
+++ b/src/SharpNeat.Tasks/BinarySixMultiplexer/BinarySixMultiplexerEvaluationScheme.cs
@@ -1,5 +1,6 @@
 ﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
+using System.Numerics;
 using SharpNeat.Evaluation;
 
 namespace SharpNeat.Tasks.BinarySixMultiplexer;
@@ -7,7 +8,9 @@ namespace SharpNeat.Tasks.BinarySixMultiplexer;
 /// <summary>
 /// Evaluation scheme for the Binary 6-Multiplexer task.
 /// </summary>
-public sealed class BinarySixMultiplexerEvaluationScheme : IBlackBoxEvaluationScheme<double>
+/// <typeparam name="TScalar">Black box input/output data type.</typeparam>
+public sealed class BinarySixMultiplexerEvaluationScheme<TScalar> : IBlackBoxEvaluationScheme<TScalar>
+    where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
 {
     /// <inheritdoc/>
     public int InputCount => 7;
@@ -28,9 +31,24 @@ public sealed class BinarySixMultiplexerEvaluationScheme : IBlackBoxEvaluationSc
     public bool EvaluatorsHaveState => false;
 
     /// <inheritdoc/>
-    public IPhenomeEvaluator<IBlackBox<double>> CreateEvaluator()
+    public IPhenomeEvaluator<IBlackBox<TScalar>> CreateEvaluator()
     {
-        return new BinarySixMultiplexerEvaluator();
+#pragma warning disable CS8603 // Possible null reference return.
+        Type scalarType = typeof(TScalar);
+
+        if(scalarType == typeof(double))
+        {
+            return new BinarySixMultiplexerEvaluatorDouble() as IPhenomeEvaluator<IBlackBox<TScalar>>;
+        }
+        else if(scalarType == typeof(float))
+        {
+            return new BinarySixMultiplexerEvaluatorFloat() as IPhenomeEvaluator<IBlackBox<TScalar>>;
+        }
+        else
+        {
+            throw new InvalidOperationException($"Unsupported scalar type '{scalarType}'.");
+        }
+#pragma warning restore CS8603 // Possible null reference return.
     }
 
     /// <inheritdoc/>

--- a/src/SharpNeat.Tasks/BinarySixMultiplexer/BinarySixMultiplexerEvaluatorDouble.cs
+++ b/src/SharpNeat.Tasks/BinarySixMultiplexer/BinarySixMultiplexerEvaluatorDouble.cs
@@ -17,7 +17,7 @@ namespace SharpNeat.Tasks.BinarySixMultiplexer;
 ///
 /// Evaluation consists of querying the provided black box for all possible input combinations (2^6 = 64).
 /// </summary>
-public sealed class BinarySixMultiplexerEvaluator : IPhenomeEvaluator<IBlackBox<double>>
+public sealed class BinarySixMultiplexerEvaluatorDouble : IPhenomeEvaluator<IBlackBox<double>>
 {
     /// <summary>
     /// Evaluate the provided black box against the Binary 6-Multiplexer task,

--- a/src/SharpNeat.Tasks/BinarySixMultiplexer/BinarySixMultiplexerEvaluatorFloat.cs
+++ b/src/SharpNeat.Tasks/BinarySixMultiplexer/BinarySixMultiplexerEvaluatorFloat.cs
@@ -1,0 +1,100 @@
+﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
+// See LICENSE.txt for details.
+using System.Diagnostics;
+using SharpNeat.Evaluation;
+
+namespace SharpNeat.Tasks.BinarySixMultiplexer;
+
+// TODO: Consider a variant on this evaluator that uses two outputs instead of one, i.e. 'false' and 'true' outputs;
+// (if both outputs are low or high then that's just an invalid response).
+
+/// <summary>
+/// Evaluator for the Binary 6-Multiplexer task.
+///
+/// Two inputs supply a binary number between 0 and 3; this number selects one of the
+/// further 4 inputs (six inputs in total). The correct response is the selected input's
+/// input signal (0 or 1).
+///
+/// Evaluation consists of querying the provided black box for all possible input combinations (2^6 = 64).
+/// </summary>
+public sealed class BinarySixMultiplexerEvaluatorFloat : IPhenomeEvaluator<IBlackBox<float>>
+{
+    /// <summary>
+    /// Evaluate the provided black box against the Binary 6-Multiplexer task,
+    /// and return its fitness score.
+    /// </summary>
+    /// <param name="box">The black box to evaluate.</param>
+    /// <returns>A new instance of <see cref="FitnessInfo"/>.</returns>
+    public FitnessInfo Evaluate(IBlackBox<float> box)
+    {
+        float fitness = 0f;
+        bool success = true;
+        Span<float> inputs = box.Inputs.Span;
+        ref float output = ref box.Outputs.Span[0];
+
+        // 64 test cases.
+        for(int i=0; i < 64; i++)
+        {
+            // Bias input.
+            inputs[0] = 1f;
+
+            // Apply bitmask to i and shift left to generate the input signals.
+            // Note. We could eliminate all the boolean logic by pre-building a table of test
+            // signals and correct responses.
+            inputs[1] = i & 0x1;
+            inputs[2] = (i>>1) & 0x1;
+            inputs[3] = (i>>2) & 0x1;
+            inputs[4] = (i>>3) & 0x1;
+            inputs[5] = (i>>4) & 0x1;
+            inputs[6] = (i>>5) & 0x1;
+
+            // Activate the black box.
+            box.Activate();
+
+            // Read output signal.
+            Clamp(ref output);
+            Debug.Assert(output >= 0.0, "Unexpected negative output.");
+            bool trueResponse = (output > 0.5);
+
+            // Determine the correct answer with somewhat cryptic bit manipulation.
+            // The condition is true if the correct answer is true (1.0).
+            if(((1 << (2 + (i & 0x3))) &i) != 0)
+            {
+                // correct answer: true.
+                // Assign fitness on sliding scale between 0.0 and 1.0 based on squared error.
+                // In tests squared error drove evolution significantly more efficiently in this domain than absolute error.
+                // Note. To base fitness on absolute error use: fitness += output;
+                fitness += 1f - ((1f - output) * (1f - output));
+
+                // Reset success flag if at least one response is wrong.
+                success &= trueResponse;
+            }
+            else
+            {
+                // correct answer: false.
+                // Assign fitness on sliding scale between 0.0 and 1.0 based on squared error.
+                // In tests squared error drove evolution significantly more efficiently in this domain than absolute error.
+                // Note. To base fitness on absolute error use: fitness += 1.0-output;
+                fitness += 1f - (output * output);
+
+                // Reset success flag if at least one response is wrong.
+                success &= !trueResponse;
+            }
+
+            // Reset black box ready for next test case.
+            box.Reset();
+        }
+
+        // If the correct answer was given in each case then add a bonus value to the fitness.
+        if(success)
+            fitness += 1_000f;
+
+        return new FitnessInfo(fitness);
+    }
+
+    private static void Clamp(ref float x)
+    {
+        if(x < 0f) x = 0f;
+        else if(x > 1f) x = 1f;
+    }
+}

--- a/src/SharpNeat.Tasks/BinarySixMultiplexer/BinarySixMultiplexerExperimentFactory.cs
+++ b/src/SharpNeat.Tasks/BinarySixMultiplexer/BinarySixMultiplexerExperimentFactory.cs
@@ -22,7 +22,7 @@ public sealed class BinarySixMultiplexerExperimentFactory : INeatExperimentFacto
         ExperimentConfig experimentConfig = JsonUtils.Deserialize<ExperimentConfig>(jsonConfigStream);
 
         // Create an evaluation scheme object for the binary 6-multiplexer task.
-        var evalScheme = new BinarySixMultiplexerEvaluationScheme();
+        var evalScheme = new BinarySixMultiplexerEvaluationScheme<double>();
 
         // Create a NeatExperiment object with the evaluation scheme,
         // and assign some default settings (these can be overridden by config).

--- a/src/SharpNeat.Tasks/BinaryThreeMultiplexer/BinaryThreeMultiplexerEvaluationScheme.cs
+++ b/src/SharpNeat.Tasks/BinaryThreeMultiplexer/BinaryThreeMultiplexerEvaluationScheme.cs
@@ -1,5 +1,6 @@
 ﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
+using System.Numerics;
 using SharpNeat.Evaluation;
 
 namespace SharpNeat.Tasks.BinaryThreeMultiplexer;
@@ -7,7 +8,9 @@ namespace SharpNeat.Tasks.BinaryThreeMultiplexer;
 /// <summary>
 /// Evaluation scheme for the Binary 3-Multiplexer task.
 /// </summary>
-public sealed class BinaryThreeMultiplexerEvaluationScheme : IBlackBoxEvaluationScheme<double>
+/// <typeparam name="TScalar">Black box input/output data type.</typeparam>
+public sealed class BinaryThreeMultiplexerEvaluationScheme<TScalar> : IBlackBoxEvaluationScheme<TScalar>
+    where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
 {
     /// <inheritdoc/>
     public int InputCount => 4;
@@ -28,9 +31,9 @@ public sealed class BinaryThreeMultiplexerEvaluationScheme : IBlackBoxEvaluation
     public bool EvaluatorsHaveState => false;
 
     /// <inheritdoc/>
-    public IPhenomeEvaluator<IBlackBox<double>> CreateEvaluator()
+    public IPhenomeEvaluator<IBlackBox<TScalar>> CreateEvaluator()
     {
-        return new BinaryThreeMultiplexerEvaluator();
+        return new BinaryThreeMultiplexerEvaluator<TScalar>();
     }
 
     /// <inheritdoc/>

--- a/src/SharpNeat.Tasks/BinaryThreeMultiplexer/BinaryThreeMultiplexerEvaluator.cs
+++ b/src/SharpNeat.Tasks/BinaryThreeMultiplexer/BinaryThreeMultiplexerEvaluator.cs
@@ -1,6 +1,6 @@
 ﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
-using System.Diagnostics;
+using System.Numerics;
 using SharpNeat.Evaluation;
 
 namespace SharpNeat.Tasks.BinaryThreeMultiplexer;
@@ -16,33 +16,38 @@ namespace SharpNeat.Tasks.BinaryThreeMultiplexer;
 ///
 /// Evaluation consists of querying the provided black box for all possible input combinations (2^3 = 8).
 /// </summary>
-public sealed class BinaryThreeMultiplexerEvaluator : IPhenomeEvaluator<IBlackBox<double>>
+/// <typeparam name="TScalar">Black box input/output data type.</typeparam>
+public sealed class BinaryThreeMultiplexerEvaluator<TScalar> : IPhenomeEvaluator<IBlackBox<TScalar>>
+    where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
 {
+    static readonly TScalar Half = TScalar.CreateChecked(0.5);
+    static readonly TScalar Hundred = TScalar.CreateChecked(100.0);
+
     /// <summary>
     /// Evaluate the provided black box against the Binary 3-Multiplexer task,
     /// and return its fitness score.
     /// </summary>
     /// <param name="box">The black box to evaluate.</param>
     /// <returns>A new instance of <see cref="FitnessInfo"/>.</returns>
-    public FitnessInfo Evaluate(IBlackBox<double> box)
+    public FitnessInfo Evaluate(IBlackBox<TScalar> box)
     {
-        double fitness = 0.0;
+        TScalar fitness = TScalar.Zero;
         bool success = true;
-        Span<double> inputs = box.Inputs.Span;
-        Span<double> outputs = box.Outputs.Span;
+        Span<TScalar> inputs = box.Inputs.Span;
+        Span<TScalar> outputs = box.Outputs.Span;
 
         // 8 test cases.
         for(int i=0; i < 8; i++)
         {
             // Bias input.
-            inputs[0] = 1.0;
+            inputs[0] = TScalar.One;
 
             // Apply bitmask to i and shift left to generate the input signals.
             // Note. We could eliminate all the boolean logic by pre-building a table of test
             // signals and correct responses.
             for(int tmp = i, j=1; j < 4; j++)
             {
-                inputs[j] = tmp & 0x1;
+                inputs[j] = TScalar.CreateSaturating(tmp & 0x1);
                 tmp >>= 1;
             }
 
@@ -50,10 +55,9 @@ public sealed class BinaryThreeMultiplexerEvaluator : IPhenomeEvaluator<IBlackBo
             box.Activate();
 
             // Read output signal.
-            double output = outputs[0];
+            TScalar output = outputs[0];
             Clamp(ref output);
-            Debug.Assert(output >= 0.0, "Unexpected negative output.");
-            bool trueResponse = (output > 0.5);
+            bool trueResponse = (output > Half);
 
             // Determine the correct answer with somewhat cryptic bit manipulation.
             // The condition is true if the correct answer is true (1.0).
@@ -63,7 +67,7 @@ public sealed class BinaryThreeMultiplexerEvaluator : IPhenomeEvaluator<IBlackBo
                 // Assign fitness on sliding scale between 0.0 and 1.0 based on squared error.
                 // In tests squared error drove evolution significantly more efficiently in this domain than absolute error.
                 // Note. To base fitness on absolute error use: fitness += output;
-                fitness += 1.0 - ((1.0 - output) * (1.0 - output));
+                fitness += TScalar.One - ((TScalar.One - output) * (TScalar.One - output));
 
                 // Reset success flag if at least one response is wrong.
                 success &= trueResponse;
@@ -74,7 +78,7 @@ public sealed class BinaryThreeMultiplexerEvaluator : IPhenomeEvaluator<IBlackBo
                 // Assign fitness on sliding scale between 0.0 and 1.0 based on squared error.
                 // In tests squared error drove evolution significantly more efficiently in this domain than absolute error.
                 // Note. To base fitness on absolute error use: fitness += 1.0-output;
-                fitness += 1.0 - (output * output);
+                fitness += TScalar.One - (output * output);
 
                 // Reset success flag if at least one response is wrong.
                 success &= !trueResponse;
@@ -86,14 +90,14 @@ public sealed class BinaryThreeMultiplexerEvaluator : IPhenomeEvaluator<IBlackBo
 
         // If the correct answer was given in each case then add a bonus value to the fitness.
         if(success)
-            fitness += 100.0;
+            fitness += Hundred;
 
-        return new FitnessInfo(fitness);
+        return new FitnessInfo(double.CreateSaturating(fitness));
     }
 
-    private static void Clamp(ref double x)
+    private static void Clamp(ref TScalar x)
     {
-        if(x < 0.0) x = 0.0;
-        else if(x > 1.0) x = 1.0;
+        if(x < TScalar.Zero) x = TScalar.Zero;
+        else if(x > TScalar.One) x = TScalar.One;
     }
 }

--- a/src/SharpNeat.Tasks/BinaryThreeMultiplexer/BinaryThreeMultiplexerExperimentFactory.cs
+++ b/src/SharpNeat.Tasks/BinaryThreeMultiplexer/BinaryThreeMultiplexerExperimentFactory.cs
@@ -22,7 +22,7 @@ public sealed class BinaryThreeMultiplexerExperimentFactory : INeatExperimentFac
         ExperimentConfig experimentConfig = JsonUtils.Deserialize<ExperimentConfig>(jsonConfigStream);
 
         // Create an evaluation scheme object for the binary 3-multiplexer task.
-        var evalScheme = new BinaryThreeMultiplexerEvaluationScheme();
+        var evalScheme = new BinaryThreeMultiplexerEvaluationScheme<double>();
 
         // Create a NeatExperiment object with the evaluation scheme,
         // and assign some default settings (these can be overridden by config).

--- a/src/SharpNeat.Tasks/BinaryTwentyMultiplexer/BinaryTwentyMultiplexerEvaluationScheme.cs
+++ b/src/SharpNeat.Tasks/BinaryTwentyMultiplexer/BinaryTwentyMultiplexerEvaluationScheme.cs
@@ -1,5 +1,6 @@
 ﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
+using System.Numerics;
 using SharpNeat.Evaluation;
 
 namespace SharpNeat.Tasks.BinaryTwentyMultiplexer;
@@ -7,7 +8,9 @@ namespace SharpNeat.Tasks.BinaryTwentyMultiplexer;
 /// <summary>
 /// Evaluation scheme for the Binary 20-Multiplexer task.
 /// </summary>
-public sealed class BinaryTwentyMultiplexerEvaluationScheme : IBlackBoxEvaluationScheme<double>
+/// <typeparam name="TScalar">Black box input/output data type.</typeparam>
+public sealed class BinaryTwentyMultiplexerEvaluationScheme<TScalar> : IBlackBoxEvaluationScheme<TScalar>
+    where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
 {
     /// <inheritdoc/>
     public int InputCount => 21;
@@ -28,9 +31,24 @@ public sealed class BinaryTwentyMultiplexerEvaluationScheme : IBlackBoxEvaluatio
     public bool EvaluatorsHaveState => false;
 
     /// <inheritdoc/>
-    public IPhenomeEvaluator<IBlackBox<double>> CreateEvaluator()
+    public IPhenomeEvaluator<IBlackBox<TScalar>> CreateEvaluator()
     {
-        return new BinaryTwentyMultiplexerEvaluator();
+#pragma warning disable CS8603 // Possible null reference return.
+        Type scalarType = typeof(TScalar);
+
+        if(scalarType == typeof(double))
+        {
+            return new BinaryTwentyMultiplexerEvaluatorDouble() as IPhenomeEvaluator<IBlackBox<TScalar>>;
+        }
+        else if(scalarType == typeof(float))
+        {
+            return new BinaryTwentyMultiplexerEvaluatorFloat() as IPhenomeEvaluator<IBlackBox<TScalar>>;
+        }
+        else
+        {
+            throw new InvalidOperationException($"Unsupported scalar type '{scalarType}'.");
+        }
+#pragma warning restore CS8603 // Possible null reference return.
     }
 
     /// <inheritdoc/>

--- a/src/SharpNeat.Tasks/BinaryTwentyMultiplexer/BinaryTwentyMultiplexerEvaluatorDouble.cs
+++ b/src/SharpNeat.Tasks/BinaryTwentyMultiplexer/BinaryTwentyMultiplexerEvaluatorDouble.cs
@@ -12,7 +12,7 @@ namespace SharpNeat.Tasks.BinaryTwentyMultiplexer;
 ///
 /// The correct output response is the binary value of the input to the addressed data input.
 /// </summary>
-public sealed class BinaryTwentyMultiplexerEvaluator : IPhenomeEvaluator<IBlackBox<double>>
+public sealed class BinaryTwentyMultiplexerEvaluatorDouble : IPhenomeEvaluator<IBlackBox<double>>
 {
     /// <summary>
     /// Evaluate the provided black box against the Binary 11-Multiplexer task,

--- a/src/SharpNeat.Tasks/BinaryTwentyMultiplexer/BinaryTwentyMultiplexerEvaluatorFloat.cs
+++ b/src/SharpNeat.Tasks/BinaryTwentyMultiplexer/BinaryTwentyMultiplexerEvaluatorFloat.cs
@@ -1,0 +1,130 @@
+﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
+// See LICENSE.txt for details.
+using SharpNeat.Evaluation;
+
+namespace SharpNeat.Tasks.BinaryTwentyMultiplexer;
+
+/// <summary>
+/// Evaluator for the Binary 20-Multiplexer task.
+///
+/// Four 'address' inputs supply a binary number between 0 and 15; this number selects one of the
+/// 16 'data' inputs; resulting in 20 inputs in total (21 with the bias input).
+///
+/// The correct output response is the binary value of the input to the addressed data input.
+/// </summary>
+public sealed class BinaryTwentyMultiplexerEvaluatorFloat : IPhenomeEvaluator<IBlackBox<float>>
+{
+    /// <summary>
+    /// Evaluate the provided black box against the Binary 11-Multiplexer task,
+    /// and return its fitness score.
+    /// </summary>
+    /// <param name="box">The black box to evaluate.</param>
+    /// <returns>A new instance of <see cref="FitnessInfo"/>.</returns>
+    public FitnessInfo Evaluate(IBlackBox<float> box)
+    {
+        float fitness = 0f;
+        Span<float> inputs = box.Inputs.Span;
+        Span<float> dataInputs = inputs.Slice(5, 16);
+        ref float output = ref box.Outputs.Span[0];
+
+        // Bias input.
+        inputs[0] = 1f;
+
+        // Loop through the 16 addresses.
+        for(int addr=0; addr < 16; addr++)
+        {
+            // Set the four address inputs.
+            inputs[1] = addr & 0x1;
+            inputs[2] = (addr >> 1) & 0x1;
+            inputs[3] = (addr >> 2) & 0x1;
+            inputs[4] = (addr >> 3) & 0x1;
+
+            // Evaluate against 128 test input patterns.
+            EvaluateTestInputPatterns(
+                box, dataInputs,
+                ref output,
+                addr,
+                ref fitness);
+        }
+
+        return new FitnessInfo(fitness);
+    }
+
+    private static void EvaluateTestInputPatterns(
+        IBlackBox<float> box,
+        Span<float> dataInputs,
+        ref float output,
+        int addr,
+        ref float fitness)
+    {
+        // Allocate storage for the input pattern values.
+        Span<float> pattern = stackalloc float[6];
+
+        // Enumerate through the 64 input patterns (every possible combination of 6 bits)
+        for(int i=0; i < 64; i++)
+        {
+            // Copy the first 6 bits of 'i' into the elements of 'pattern'.
+            pattern[0] = i & 0x1;
+            pattern[1] = (i>>1) & 0x1;
+            pattern[2] = (i>>2) & 0x1;
+            pattern[3] = (i>>3) & 0x1;
+            pattern[4] = (i>>4) & 0x1;
+            pattern[5] = (i>>5) & 0x1;
+
+            // Repeat the pattern in the slice before the addressed input.
+            Fill(dataInputs.Slice(0, addr), pattern);
+
+            // Set the value of the addressed data input to zero.
+            dataInputs[addr] = 0f;
+
+            // Repeat the pattern in the slice after the addressed input.
+            Fill(dataInputs.Slice(addr + 1), pattern);
+
+            // Activate the black box to get the response/output value.
+            box.Activate();
+
+            // Calculate a fitness for this evaluation instance; and add the result to an accumulating fitness score.
+            Clamp(ref output);
+            fitness += 1f - (output * output);
+
+            // Now evaluate with the addressed data input set to one.
+            dataInputs[addr] = 1f;
+
+            // Activate the black box to get the response/output value.
+            box.Activate();
+
+            // Calculate a fitness for this evaluation instance; and add the result to an accumulating fitness score.
+            Clamp(ref output);
+            fitness += 1f - ((1f - output) * (1f - output));
+        }
+    }
+
+    private static void Clamp(ref float x)
+    {
+        if(x < 0f) x = 0f;
+        else if(x > 1f) x = 1f;
+    }
+
+    // TODO: Consider moving to Redzen.SpanUtils.
+    /// <summary>
+    /// Fill the elements of <paramref name="span"/> with repeating copies of the values from <paramref name="pattern"/>.
+    /// </summary>
+    /// <param name="span">The span to fill.</param>
+    /// <param name="pattern">The pattern span.</param>
+    private static void Fill(
+        Span<float> span,
+        ReadOnlySpan<float> pattern)
+    {
+        // Loop over 'pattern' sized slices of the target span, copying the pattern into each slice.
+        for(; span.Length >= pattern.Length; span = span.Slice(pattern.Length))
+        {
+            pattern.CopyTo(span);
+        }
+
+        // Handle remaining elements (if any).
+        if(span.Length != 0)
+        {
+            pattern.Slice(0, span.Length).CopyTo(span);
+        }
+    }
+}

--- a/src/SharpNeat.Tasks/BinaryTwentyMultiplexer/BinaryTwentyMultiplexerExperimentFactory.cs
+++ b/src/SharpNeat.Tasks/BinaryTwentyMultiplexer/BinaryTwentyMultiplexerExperimentFactory.cs
@@ -22,7 +22,7 @@ public sealed class BinaryTwentyMultiplexerExperimentFactory : INeatExperimentFa
         ExperimentConfig experimentConfig = JsonUtils.Deserialize<ExperimentConfig>(jsonConfigStream);
 
         // Create an evaluation scheme object for the binary 20-multiplexer task.
-        var evalScheme = new BinaryTwentyMultiplexerEvaluationScheme();
+        var evalScheme = new BinaryTwentyMultiplexerEvaluationScheme<double>();
 
         // Create a NeatExperiment object with the evaluation scheme,
         // and assign some default settings (these can be overridden by config).

--- a/src/SharpNeat.Tasks/CartPole/DoublePole/CartDoublePoleEvaluationScheme.cs
+++ b/src/SharpNeat.Tasks/CartPole/DoublePole/CartDoublePoleEvaluationScheme.cs
@@ -49,7 +49,6 @@ public sealed class CartDoublePoleEvaluationScheme<TScalar> : IBlackBoxEvaluatio
             throw new InvalidOperationException($"Unsupported scalar type '{scalarType}'.");
         }
 #pragma warning restore CS8603 // Possible null reference return.
-
     }
 
     /// <inheritdoc/>

--- a/src/SharpNeat.Tasks/CartPole/DoublePole/CartDoublePoleEvaluationScheme.cs
+++ b/src/SharpNeat.Tasks/CartPole/DoublePole/CartDoublePoleEvaluationScheme.cs
@@ -1,5 +1,6 @@
 ﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
+using System.Numerics;
 using SharpNeat.Evaluation;
 
 namespace SharpNeat.Tasks.CartPole.DoublePole;
@@ -7,7 +8,9 @@ namespace SharpNeat.Tasks.CartPole.DoublePole;
 /// <summary>
 /// Evaluation scheme for the cart and pole balancing task, with two poles.
 /// </summary>
-public sealed class CartDoublePoleEvaluationScheme : IBlackBoxEvaluationScheme<double>
+/// <typeparam name="TScalar">Black box input/output data type.</typeparam>
+public sealed class CartDoublePoleEvaluationScheme<TScalar> : IBlackBoxEvaluationScheme<TScalar>
+    where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
 {
     /// <inheritdoc/>
     public int InputCount => 7;
@@ -28,9 +31,25 @@ public sealed class CartDoublePoleEvaluationScheme : IBlackBoxEvaluationScheme<d
     public bool EvaluatorsHaveState => true;
 
     /// <inheritdoc/>
-    public IPhenomeEvaluator<IBlackBox<double>> CreateEvaluator()
+    public IPhenomeEvaluator<IBlackBox<TScalar>> CreateEvaluator()
     {
-        return new CartDoublePoleEvaluator();
+#pragma warning disable CS8603 // Possible null reference return.
+        Type scalarType = typeof(TScalar);
+
+        if(scalarType == typeof(double))
+        {
+            return new CartDoublePoleEvaluatorDouble() as IPhenomeEvaluator<IBlackBox<TScalar>>;
+        }
+        else if(scalarType == typeof(float))
+        {
+            return new CartDoublePoleEvaluatorFloat() as IPhenomeEvaluator<IBlackBox<TScalar>>;
+        }
+        else
+        {
+            throw new InvalidOperationException($"Unsupported scalar type '{scalarType}'.");
+        }
+#pragma warning restore CS8603 // Possible null reference return.
+
     }
 
     /// <inheritdoc/>

--- a/src/SharpNeat.Tasks/CartPole/DoublePole/CartDoublePoleEvaluatorDouble.cs
+++ b/src/SharpNeat.Tasks/CartPole/DoublePole/CartDoublePoleEvaluatorDouble.cs
@@ -1,0 +1,202 @@
+﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
+// See LICENSE.txt for details.
+using SharpNeat.Evaluation;
+
+namespace SharpNeat.Tasks.CartPole.DoublePole;
+
+/// <summary>
+/// Evaluator for the cart and double pole balancing task.
+/// </summary>
+/// <remarks>
+/// This task is solvable by SharpNEAT, but not on every run. This is likely due to 'deceptive' local maxima in the fitness landscape.
+/// As such this task would be a reasonable choice for research into addressing the problem of fitness landscape deception.
+///
+/// This task can be made more difficult by not providing the velocity information (the cart and the two pole angular velocities)
+/// to the neural network. Difficulty can be further increases by making the two pole lengths increasingly similar, with the task
+/// becoming impossible when the poles have the same length.
+///
+/// As things stand the problem is difficult enough in its current form, therefore we provide velocity inputs and define two very
+/// different pole lengths.
+/// </remarks>
+public sealed class CartDoublePoleEvaluatorDouble : IPhenomeEvaluator<IBlackBox<double>>
+{
+    #region Constants
+
+    // Maximum force applied to the cart, in Newtons.
+    const float __MaxForce = 10f;
+
+    // Some useful angles (in radians).
+    const float __MaxPoleAngle = (36f * MathF.PI) / 180f;
+    const float __MaxPoleAngle_Reciprocal = 1f / __MaxPoleAngle;
+
+    // Track half length (in metres).
+    const float __TrackLengthHalf = 2f;
+    const float __TrackLengthHalf_Reciprocal = 1f / __TrackLengthHalf;
+
+    #endregion
+
+    #region Instance Fields
+
+    readonly int _maxTimesteps;
+    readonly float _maxTimesteps_Reciprocal = 1f;
+    readonly CartDoublePolePhysicsRK4 _physics;
+
+    #endregion
+
+    #region Constructors
+
+    /// <summary>
+    /// Construct evaluator with default task arguments/variables.
+    /// </summary>
+    /// <remarks>
+    /// Default to 960 timesteps, or 960/16 = 60 seconds of clock time.</remarks>
+    public CartDoublePoleEvaluatorDouble()
+        : this(960)
+    {
+    }
+
+    /// <summary>
+    /// Construct evaluator with the provided task arguments/variables.
+    /// </summary>
+    /// <param name="maxTimesteps">The maximum number of timesteps to run the physics simulation for.</param>
+    public CartDoublePoleEvaluatorDouble(int maxTimesteps)
+    {
+        _maxTimesteps = maxTimesteps;
+        _maxTimesteps_Reciprocal = 1f / maxTimesteps;
+        _physics = new CartDoublePolePhysicsRK4();
+    }
+
+    #endregion
+
+    #region Public Methods
+
+    /// <summary>
+    /// Evaluate the provided black box against the cart and double pole balancing task,
+    /// and return its fitness score.
+    /// </summary>
+    /// <param name="box">The black box to evaluate.</param>
+    /// <returns>A new instance of <see cref="FitnessInfo"/>.</returns>
+    public FitnessInfo Evaluate(IBlackBox<double> box)
+    {
+        // The evaluation consists of four separate trials, each with their own fitness score.
+        // The final overall fitness is given by the root mean squared (RMS) fitness. Using an RMS
+        // score ensures that improvements in the worst scoring trial are prioritised (by evolution) over
+        // a similar level of improvement in a better scoring trial. RMS also has the nice quality of giving
+        // a maximum overall fitness that is equal to the max fitness for a single trial.
+
+        // Keep a running sum of the squared fitness scores.
+        float fitnessSqrSum = 0f;
+
+        // Trial 1.
+        float fitness = RunTrial(box, 0.0f, DegreesToRadians(1f), 0f);
+        fitnessSqrSum += fitness * fitness;
+
+        // Trial 2.
+        fitness = RunTrial(box, 0.0f, DegreesToRadians(4f), 0f);
+        fitnessSqrSum += fitness * fitness;
+
+        // Trial 3.
+        fitness = RunTrial(box, 0.0f, DegreesToRadians(-2f), 0f);
+        fitnessSqrSum += fitness * fitness;
+
+        // Trial 4.
+        fitness = RunTrial(box, 0.0f, DegreesToRadians(-3f), 0f);
+        fitnessSqrSum += fitness * fitness;
+
+        // Calculate the final overall fitness score.
+        // Take the mean of the sum of squared fitnesses, and then take the square root.
+        fitness = MathF.Sqrt(fitnessSqrSum / 4f);
+        return new FitnessInfo(fitness);
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    /// <summary>
+    /// Run a single cart-pole simulation/trial on the given black box, and with the given initial model state.
+    /// </summary>
+    /// <param name="box">The black box (neural net) to evaluate.</param>
+    /// <param name="cartPos">Cart position on the track.</param>
+    /// <param name="poleAngle1">Pole 1 angle in radians.</param>
+    /// <param name="poleAngle2">Pole 2 angle in radians.</param>
+    /// <returns>Fitness score.</returns>
+    public float RunTrial(
+        IBlackBox<double> box,
+        float cartPos,
+        float poleAngle1,
+        float poleAngle2)
+    {
+        // Reset black box state.
+        box.Reset();
+
+        // Reset model state.
+        _physics.ResetState(cartPos, poleAngle1, poleAngle2);
+
+        // Get a local variable ref to the internal model state array.
+        float[] state = _physics.State;
+
+        // Get the blackbox input and output spans.
+        var inputs = box.Inputs.Span;
+        var outputs = box.Outputs.Span;
+
+        // Run the cart-pole simulation.
+        int timestep = 0;
+        for(; timestep < _maxTimesteps; timestep++)
+        {
+            // Provide model state to the black box inputs (normalised to +-1.0).
+            inputs[0] = 1.0; // Bias input.
+            inputs[1] = state[0] * __TrackLengthHalf_Reciprocal;   // Cart X position range is +-__TrackLengthHalf; here we normalize to [-1,1].
+            inputs[2] = state[1];                                  // Cart velocity. Typical range is approx. +-10.
+            inputs[3] = state[2] * __MaxPoleAngle_Reciprocal;      // Pole 1 angle. Range is +-__MaxPoleAngle radians; here we normalize to [-1,1].
+            inputs[4] = state[3] * 0.2;                            // Pole 1 angular velocity. Typical range is approx. +-5.
+            inputs[5] = state[4] * __MaxPoleAngle_Reciprocal;      // Pole 2 angle.
+            inputs[6] = state[5] * 0.2;                            // Pole 2 angular velocity.
+
+            // Activate the network.
+            box.Activate();
+
+            // Read the output to determine the force to be applied to the cart by the controller.
+            float force = (float)(outputs[0] - 0.5) * 2f;
+            ClipForce(ref force);
+            force *= __MaxForce;
+
+            // Update model state, i.e. move the model forward by one timestep.
+            _physics.Update(force);
+
+            // Check for failure state. I.e. has the cart run off the ends of the track, or has either of the pole
+            // angles exceeded the defined threshold.
+            if(MathF.Abs(state[0]) > __TrackLengthHalf || MathF.Abs(state[2]) > __MaxPoleAngle || MathF.Abs(state[4]) > __MaxPoleAngle)
+                break;
+        }
+
+        // Fitness is given by the combination of two fitness components:
+        // 1) Amount of simulation time that elapsed before the pole angle and/or cart position threshold was exceeded. Max score is 99 if the
+        //    end of the trial is reached without exceeding any thresholds.
+        // 2) Cart position component. Max fitness of 1.0 for a cart position of zero (i.e. the cart is in the middle of the track range);
+        //
+        // Therefore the maximum possible fitness is 100.0.
+        float fitness =
+              (timestep * _maxTimesteps_Reciprocal * 99f)
+            + (1f - (MathF.Min(MathF.Abs(state[0]), __TrackLengthHalf) * __TrackLengthHalf_Reciprocal));
+
+        return fitness;
+    }
+
+    #endregion
+
+    #region Private Static Methods
+
+    private static void ClipForce(ref float x)
+    {
+        if(x < -1f) x = -1f;
+        else if(x > 1f) x = 1f;
+    }
+
+    private static float DegreesToRadians(float degrees)
+    {
+        return (MathF.PI * degrees) / 180f;
+    }
+
+    #endregion
+}

--- a/src/SharpNeat.Tasks/CartPole/DoublePole/CartDoublePoleEvaluatorFloat.cs
+++ b/src/SharpNeat.Tasks/CartPole/DoublePole/CartDoublePoleEvaluatorFloat.cs
@@ -18,7 +18,7 @@ namespace SharpNeat.Tasks.CartPole.DoublePole;
 /// As things stand the problem is difficult enough in its current form, therefore we provide velocity inputs and define two very
 /// different pole lengths.
 /// </remarks>
-public sealed class CartDoublePoleEvaluator : IPhenomeEvaluator<IBlackBox<double>>
+public sealed class CartDoublePoleEvaluatorFloat : IPhenomeEvaluator<IBlackBox<float>>
 {
     #region Constants
 
@@ -50,7 +50,7 @@ public sealed class CartDoublePoleEvaluator : IPhenomeEvaluator<IBlackBox<double
     /// </summary>
     /// <remarks>
     /// Default to 960 timesteps, or 960/16 = 60 seconds of clock time.</remarks>
-    public CartDoublePoleEvaluator()
+    public CartDoublePoleEvaluatorFloat()
         : this(960)
     {
     }
@@ -59,7 +59,7 @@ public sealed class CartDoublePoleEvaluator : IPhenomeEvaluator<IBlackBox<double
     /// Construct evaluator with the provided task arguments/variables.
     /// </summary>
     /// <param name="maxTimesteps">The maximum number of timesteps to run the physics simulation for.</param>
-    public CartDoublePoleEvaluator(int maxTimesteps)
+    public CartDoublePoleEvaluatorFloat(int maxTimesteps)
     {
         _maxTimesteps = maxTimesteps;
         _maxTimesteps_Reciprocal = 1f / maxTimesteps;
@@ -76,7 +76,7 @@ public sealed class CartDoublePoleEvaluator : IPhenomeEvaluator<IBlackBox<double
     /// </summary>
     /// <param name="box">The black box to evaluate.</param>
     /// <returns>A new instance of <see cref="FitnessInfo"/>.</returns>
-    public FitnessInfo Evaluate(IBlackBox<double> box)
+    public FitnessInfo Evaluate(IBlackBox<float> box)
     {
         // The evaluation consists of four separate trials, each with their own fitness score.
         // The final overall fitness is given by the root mean squared (RMS) fitness. Using an RMS
@@ -122,7 +122,7 @@ public sealed class CartDoublePoleEvaluator : IPhenomeEvaluator<IBlackBox<double
     /// <param name="poleAngle2">Pole 2 angle in radians.</param>
     /// <returns>Fitness score.</returns>
     public float RunTrial(
-        IBlackBox<double> box,
+        IBlackBox<float> box,
         float cartPos,
         float poleAngle1,
         float poleAngle2)
@@ -145,13 +145,13 @@ public sealed class CartDoublePoleEvaluator : IPhenomeEvaluator<IBlackBox<double
         for(; timestep < _maxTimesteps; timestep++)
         {
             // Provide model state to the black box inputs (normalised to +-1.0).
-            inputs[0] = 1.0; // Bias input.
+            inputs[0] = 1f; // Bias input.
             inputs[1] = state[0] * __TrackLengthHalf_Reciprocal;   // Cart X position range is +-__TrackLengthHalf; here we normalize to [-1,1].
             inputs[2] = state[1];                                  // Cart velocity. Typical range is approx. +-10.
             inputs[3] = state[2] * __MaxPoleAngle_Reciprocal;      // Pole 1 angle. Range is +-__MaxPoleAngle radians; here we normalize to [-1,1].
-            inputs[4] = state[3] * 0.2;                            // Pole 1 angular velocity. Typical range is approx. +-5.
+            inputs[4] = state[3] * 0.2f;                           // Pole 1 angular velocity. Typical range is approx. +-5.
             inputs[5] = state[4] * __MaxPoleAngle_Reciprocal;      // Pole 2 angle.
-            inputs[6] = state[5] * 0.2;                            // Pole 2 angular velocity.
+            inputs[6] = state[5] * 0.2f;                           // Pole 2 angular velocity.
 
             // Activate the network.
             box.Activate();

--- a/src/SharpNeat.Tasks/CartPole/DoublePole/CartDoublePoleExperimentFactory.cs
+++ b/src/SharpNeat.Tasks/CartPole/DoublePole/CartDoublePoleExperimentFactory.cs
@@ -22,7 +22,7 @@ public sealed class CartDoublePoleExperimentFactory : INeatExperimentFactory
         ExperimentConfig experimentConfig = JsonUtils.Deserialize<ExperimentConfig>(jsonConfigStream);
 
         // Create an evaluation scheme object for the Single Pole Balancing task.
-        var evalScheme = new CartDoublePoleEvaluationScheme();
+        var evalScheme = new CartDoublePoleEvaluationScheme<double>();
 
         // Create a NeatExperiment object with the evaluation scheme,
         // and assign some default settings (these can be overridden by config).

--- a/src/SharpNeat.Tasks/CartPole/SinglePole/CartSinglePoleEvaluationScheme.cs
+++ b/src/SharpNeat.Tasks/CartPole/SinglePole/CartSinglePoleEvaluationScheme.cs
@@ -1,5 +1,6 @@
 ﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
+using System.Numerics;
 using SharpNeat.Evaluation;
 
 namespace SharpNeat.Tasks.CartPole.SinglePole;
@@ -7,7 +8,9 @@ namespace SharpNeat.Tasks.CartPole.SinglePole;
 /// <summary>
 /// Evaluation scheme for the cart and pole balancing task, with a single pole.
 /// </summary>
-public sealed class CartSinglePoleEvaluationScheme : IBlackBoxEvaluationScheme<double>
+/// <typeparam name="TScalar">Black box input/output data type.</typeparam>
+public sealed class CartSinglePoleEvaluationScheme<TScalar> : IBlackBoxEvaluationScheme<TScalar>
+    where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
 {
     /// <inheritdoc/>
     public int InputCount => 3;
@@ -28,9 +31,24 @@ public sealed class CartSinglePoleEvaluationScheme : IBlackBoxEvaluationScheme<d
     public bool EvaluatorsHaveState => true;
 
     /// <inheritdoc/>
-    public IPhenomeEvaluator<IBlackBox<double>> CreateEvaluator()
+    public IPhenomeEvaluator<IBlackBox<TScalar>> CreateEvaluator()
     {
-        return new CartSinglePoleEvaluator();
+#pragma warning disable CS8603 // Possible null reference return.
+        Type scalarType = typeof(TScalar);
+
+        if(scalarType == typeof(double))
+        {
+            return new CartSinglePoleEvaluatorDouble() as IPhenomeEvaluator<IBlackBox<TScalar>>;
+        }
+        else if(scalarType == typeof(float))
+        {
+            return new CartSinglePoleEvaluatorFloat() as IPhenomeEvaluator<IBlackBox<TScalar>>;
+        }
+        else
+        {
+            throw new InvalidOperationException($"Unsupported scalar type '{scalarType}'.");
+        }
+#pragma warning restore CS8603 // Possible null reference return.
     }
 
     /// <inheritdoc/>

--- a/src/SharpNeat.Tasks/CartPole/SinglePole/CartSinglePoleEvaluatorDouble.cs
+++ b/src/SharpNeat.Tasks/CartPole/SinglePole/CartSinglePoleEvaluatorDouble.cs
@@ -1,0 +1,189 @@
+﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
+// See LICENSE.txt for details.
+using SharpNeat.Evaluation;
+
+namespace SharpNeat.Tasks.CartPole.SinglePole;
+
+/// <summary>
+/// Evaluator for the cart and single pole balancing task.
+/// </summary>
+public sealed class CartSinglePoleEvaluatorDouble : IPhenomeEvaluator<IBlackBox<double>>
+{
+    #region Constants
+
+    // Maximum force applied to the cart, in Newtons.
+    const float __MaxForce = 10f;
+
+    // Some useful angles (in radians).
+    const float __MaxPoleAngle = (16f * MathF.PI) / 180f;
+    const float __MaxPoleAngle_Reciprocal = 1f / __MaxPoleAngle;
+
+    // Track half length (in metres).
+    const float __TrackLengthHalf = 2.0f;
+    const float __TrackLengthHalf_Reciprocal = 1f / __TrackLengthHalf;
+
+    #endregion
+
+    #region Instance Fields
+
+    readonly int _maxTimesteps;
+    readonly float _maxTimesteps_Reciprocal = 1f;
+    readonly CartSinglePolePhysicsRK4 _physics;
+
+    #endregion
+
+    #region Constructors
+
+    /// <summary>
+    /// Construct evaluator with default task arguments/variables.
+    /// </summary>
+    /// <remarks>
+    /// Default to 960 timesteps, or 960/16 = 60 seconds of clock time.</remarks>
+    public CartSinglePoleEvaluatorDouble()
+        : this(960)
+    {
+    }
+
+    /// <summary>
+    /// Construct evaluator with the provided task arguments/variables.
+    /// </summary>
+    /// <param name="maxTimesteps">The maximum number of timesteps to run the physics simulation for.</param>
+    public CartSinglePoleEvaluatorDouble(int maxTimesteps)
+    {
+        _maxTimesteps = maxTimesteps;
+        _maxTimesteps_Reciprocal = 1f / maxTimesteps;
+        _physics = new CartSinglePolePhysicsRK4();
+    }
+
+    #endregion
+
+    #region Public Methods
+
+    /// <summary>
+    /// Evaluate the provided black box against the cart and single pole balancing task,
+    /// and return its fitness score.
+    /// </summary>
+    /// <param name="box">The black box to evaluate.</param>
+    /// <returns>A new instance of <see cref="FitnessInfo"/>.</returns>
+    public FitnessInfo Evaluate(IBlackBox<double> box)
+    {
+        // The evaluation consists of four separate trials, each with their own fitness score.
+        // The final overall fitness is given by the root mean squared (RMS) fitness. Using an RMS
+        // score ensures that improvements in the worst scoring trial are prioritised (by evolution) over
+        // a similar level of improvement in a better scoring trial. RMS also has the nice quality of giving
+        // a maximum overall fitness that is equal to the max fitness for a single trial.
+
+        // Keep a running sum of the squared fitness scores.
+        float fitnessSqrSum = 0f;
+
+        // Trial 1.
+        float fitness = RunTrial(box, 0.2f, DegreesToRadians(10f));
+        fitnessSqrSum += fitness * fitness;
+
+        // Trial 2.
+        fitness = RunTrial(box, -0.4f, DegreesToRadians(12f));
+        fitnessSqrSum += fitness * fitness;
+
+        // Trial 3.
+        fitness = RunTrial(box, -0.2f, DegreesToRadians(-6f));
+        fitnessSqrSum += fitness * fitness;
+
+        // Trial 4.
+        fitness = RunTrial(box, -0.6f, DegreesToRadians(-8f));
+        fitnessSqrSum += fitness * fitness;
+
+        // Calculate the final overall fitness score.
+        // Take the mean of the sum of squared fitnesses, and then take the square root.
+        fitness = MathF.Sqrt(fitnessSqrSum / 4f);
+        return new FitnessInfo(fitness);
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    /// <summary>
+    /// Run a single cart-pole simulation/trial on the given black box, and with the given initial model state.
+    /// </summary>
+    /// <param name="box">The black box (neural net) to evaluate.</param>
+    /// <param name="cartPos">Cart position on the track.</param>
+    /// <param name="poleAngle">Pole angle in radians.</param>
+    /// <returns>Fitness score.</returns>
+    public float RunTrial(
+        IBlackBox<double> box,
+        float cartPos,
+        float poleAngle)
+    {
+        // Reset black box state.
+        box.Reset();
+
+        // Reset model state.
+        _physics.ResetState(cartPos, poleAngle);
+
+        // Get a local variable ref to the internal model state array.
+        float[] state = _physics.State;
+
+        // Get the blackbox input and output spans.
+        var inputs = box.Inputs.Span;
+        var outputs = box.Outputs.Span;
+
+        // Run the cart-pole simulation.
+        int timestep = 0;
+        for(; timestep < _maxTimesteps; timestep++)
+        {
+            // Provide model state to the black box inputs (normalised to +-1.0).
+            inputs[0] = 1.0; // Bias input.
+            inputs[1] = state[0] * __TrackLengthHalf_Reciprocal; // Cart X position range is +-__TrackLengthHalf; here we normalize to [-1,1].
+            inputs[2] = state[2] * __MaxPoleAngle_Reciprocal;    // Pole angle range is +-__MaxPoleAngle radians; here we normalize to [-1,1].
+
+            // Activate the network.
+            box.Activate();
+
+            // Read the output to determine the force to be applied to the cart by the controller.
+            float force = (float)(outputs[0] - 0.5) * 2f;
+            ClipForce(ref force);
+            force *= __MaxForce;
+
+            // Update model state, i.e. move the model forward by one timestep.
+            _physics.Update(force);
+
+            // Check for failure state. I.e. has the cart run off the ends of the track, or has the pole
+            // angle exceeded the defined threshold.
+            if(MathF.Abs(state[0]) > __TrackLengthHalf || MathF.Abs(state[2]) > __MaxPoleAngle)
+                break;
+        }
+
+        // Fitness is given by the combination of four fitness components:
+        // 1) Amount of simulation time that elapsed before the pole angle and/or cart position threshold was exceeded. Max score is 80 if the
+        //    end of the trial is reached without exceeding any thresholds.
+        // 2) Cart position component. Max fitness of 1.0 for a cart position of zero (i.e. the cart is in the middle of the track range);
+        // 3) Pole angle component. Max fitness of 9.5 for a pole angle of 0 degrees (vertical pole).
+        // 4) Pole angular velocity component. Maximum fitness 9.5 for a zero velocity.
+        //
+        // Therefore the maximum possible fitness is 100.0, when the pole is perfectly stationary, and the cart is in the middle of the track.
+        float fitness =
+              (timestep * _maxTimesteps_Reciprocal * 80f)
+            + (1f - (MathF.Min(MathF.Abs(state[0]), __TrackLengthHalf) * __TrackLengthHalf_Reciprocal))
+            + ((1f - (MathF.Min(MathF.Abs(state[2]), __MaxPoleAngle) * __MaxPoleAngle_Reciprocal)) * 9.5f)
+            + ((1f - MathF.Min(MathF.Abs(state[3]), 1f)) * 9.5f);
+
+        return fitness;
+    }
+
+    #endregion
+
+    #region Private Static Methods
+
+    private static void ClipForce(ref float x)
+    {
+        if(x < -1f) x = -1f;
+        else if(x > 1f) x = 1f;
+    }
+
+    private static float DegreesToRadians(float degrees)
+    {
+        return (MathF.PI * degrees) / 180f;
+    }
+
+    #endregion
+}

--- a/src/SharpNeat.Tasks/CartPole/SinglePole/CartSinglePoleEvaluatorFloat.cs
+++ b/src/SharpNeat.Tasks/CartPole/SinglePole/CartSinglePoleEvaluatorFloat.cs
@@ -7,7 +7,7 @@ namespace SharpNeat.Tasks.CartPole.SinglePole;
 /// <summary>
 /// Evaluator for the cart and single pole balancing task.
 /// </summary>
-public sealed class CartSinglePoleEvaluator : IPhenomeEvaluator<IBlackBox<double>>
+public sealed class CartSinglePoleEvaluatorFloat : IPhenomeEvaluator<IBlackBox<float>>
 {
     #region Constants
 
@@ -39,7 +39,7 @@ public sealed class CartSinglePoleEvaluator : IPhenomeEvaluator<IBlackBox<double
     /// </summary>
     /// <remarks>
     /// Default to 960 timesteps, or 960/16 = 60 seconds of clock time.</remarks>
-    public CartSinglePoleEvaluator()
+    public CartSinglePoleEvaluatorFloat()
         : this(960)
     {
     }
@@ -48,7 +48,7 @@ public sealed class CartSinglePoleEvaluator : IPhenomeEvaluator<IBlackBox<double
     /// Construct evaluator with the provided task arguments/variables.
     /// </summary>
     /// <param name="maxTimesteps">The maximum number of timesteps to run the physics simulation for.</param>
-    public CartSinglePoleEvaluator(int maxTimesteps)
+    public CartSinglePoleEvaluatorFloat(int maxTimesteps)
     {
         _maxTimesteps = maxTimesteps;
         _maxTimesteps_Reciprocal = 1f / maxTimesteps;
@@ -65,7 +65,7 @@ public sealed class CartSinglePoleEvaluator : IPhenomeEvaluator<IBlackBox<double
     /// </summary>
     /// <param name="box">The black box to evaluate.</param>
     /// <returns>A new instance of <see cref="FitnessInfo"/>.</returns>
-    public FitnessInfo Evaluate(IBlackBox<double> box)
+    public FitnessInfo Evaluate(IBlackBox<float> box)
     {
         // The evaluation consists of four separate trials, each with their own fitness score.
         // The final overall fitness is given by the root mean squared (RMS) fitness. Using an RMS
@@ -110,7 +110,7 @@ public sealed class CartSinglePoleEvaluator : IPhenomeEvaluator<IBlackBox<double
     /// <param name="poleAngle">Pole angle in radians.</param>
     /// <returns>Fitness score.</returns>
     public float RunTrial(
-        IBlackBox<double> box,
+        IBlackBox<float> box,
         float cartPos,
         float poleAngle)
     {
@@ -132,7 +132,7 @@ public sealed class CartSinglePoleEvaluator : IPhenomeEvaluator<IBlackBox<double
         for(; timestep < _maxTimesteps; timestep++)
         {
             // Provide model state to the black box inputs (normalised to +-1.0).
-            inputs[0] = 1.0; // Bias input.
+            inputs[0] = 1f; // Bias input.
             inputs[1] = state[0] * __TrackLengthHalf_Reciprocal; // Cart X position range is +-__TrackLengthHalf; here we normalize to [-1,1].
             inputs[2] = state[2] * __MaxPoleAngle_Reciprocal;    // Pole angle range is +-__MaxPoleAngle radians; here we normalize to [-1,1].
 

--- a/src/SharpNeat.Tasks/CartPole/SinglePole/CartSinglePoleExperimentFactory.cs
+++ b/src/SharpNeat.Tasks/CartPole/SinglePole/CartSinglePoleExperimentFactory.cs
@@ -22,7 +22,7 @@ public sealed class CartSinglePoleExperimentFactory : INeatExperimentFactory
         ExperimentConfig experimentConfig = JsonUtils.Deserialize<ExperimentConfig>(jsonConfigStream);
 
         // Create an evaluation scheme object for the Single Pole Balancing task.
-        var evalScheme = new CartSinglePoleEvaluationScheme();
+        var evalScheme = new CartSinglePoleEvaluationScheme<double>();
 
         // Create a NeatExperiment object with the evaluation scheme,
         // and assign some default settings (these can be overridden by config).

--- a/src/SharpNeat.Tasks/FunctionRegression/BlackBoxProbe.cs
+++ b/src/SharpNeat.Tasks/FunctionRegression/BlackBoxProbe.cs
@@ -1,17 +1,22 @@
 ﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
 using System.Diagnostics;
+using System.Numerics;
 
 namespace SharpNeat.Tasks.FunctionRegression;
 
 /// <summary>
 /// For probing and recording the responses of instances of <see cref="IBlackBox{T}"/>.
 /// </summary>
-public sealed class BlackBoxProbe : IBlackBoxProbe
+/// <typeparam name="TScalar">Black box input/output data type.</typeparam>
+public sealed class BlackBoxProbe<TScalar> : IBlackBoxProbe<TScalar>
+    where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
 {
-    readonly ParamSamplingInfo _paramSamplingInfo;
-    readonly double _offset;
-    readonly double _scale;
+    static readonly TScalar Half = TScalar.CreateChecked(0.5);
+
+    readonly ParamSamplingInfo<TScalar> _paramSamplingInfo;
+    readonly TScalar _offset;
+    readonly TScalar _scale;
 
     /// <summary>
     /// Construct a new instance.
@@ -19,7 +24,7 @@ public sealed class BlackBoxProbe : IBlackBoxProbe
     /// <param name="paramSamplingInfo">Parameter sampling info.</param>
     /// <param name="offset">Offset to apply to each neural network output response.</param>
     /// <param name="scale">Scaling factor to apply to each neural network output response.</param>
-    public BlackBoxProbe(ParamSamplingInfo paramSamplingInfo, double offset, double scale)
+    public BlackBoxProbe(ParamSamplingInfo<TScalar> paramSamplingInfo, TScalar offset, TScalar scale)
     {
         _paramSamplingInfo = paramSamplingInfo;
         _offset = offset;
@@ -27,7 +32,7 @@ public sealed class BlackBoxProbe : IBlackBoxProbe
     }
 
     /// <inheritdoc/>
-    public void Probe(IBlackBox<double> box, double[] responseArr)
+    public void Probe(IBlackBox<TScalar> box, TScalar[] responseArr)
     {
         Debug.Assert(responseArr.Length == _paramSamplingInfo.SampleResolution);
 
@@ -35,14 +40,14 @@ public sealed class BlackBoxProbe : IBlackBoxProbe
         var inputs = box.Inputs.Span;
         var outputs = box.Outputs.Span;
 
-        double[] xArr = _paramSamplingInfo.XArrNetwork;
+        TScalar[] xArr = _paramSamplingInfo.XArrNetwork;
         for(int i=0; i < xArr.Length; i++)
         {
             // Reset black box internal state.
             box.Reset();
 
             // Set bias input, and function input value.
-            inputs[0] = 1.0;
+            inputs[0] = TScalar.One;
             inputs[1] = xArr[i];
 
             // Activate the black box.
@@ -51,15 +56,15 @@ public sealed class BlackBoxProbe : IBlackBoxProbe
             // Get the black box's output value.
             // TODO: Review this scheme. This replicates the behaviour in SharpNEAT 2.x but not sure if it's ideal,
             // for one it depends on the output range of the neural net activation function in use.
-            double output = outputs[0];
+            TScalar output = outputs[0];
             Clip(ref output);
-            responseArr[i] = ((output - 0.5) * _scale) + _offset;
+            responseArr[i] = ((output - Half) * _scale) + _offset;
         }
     }
 
-    private static void Clip(ref double x)
+    private static void Clip(ref TScalar x)
     {
-        if(x < 0.0) x = 0.0;
-        else if(x > 1.0) x = 1.0;
+        if(x < TScalar.Zero) x = TScalar.Zero;
+        else if(x > TScalar.One) x = TScalar.One;
     }
 }

--- a/src/SharpNeat.Tasks/FunctionRegression/FuncRegressionEvaluator.cs
+++ b/src/SharpNeat.Tasks/FunctionRegression/FuncRegressionEvaluator.cs
@@ -1,5 +1,6 @@
 ﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
+using System.Numerics;
 using Redzen;
 using SharpNeat.Evaluation;
 
@@ -13,21 +14,23 @@ namespace SharpNeat.Tasks.FunctionRegression;
 /// Evaluation consists of querying the provided black box for a number of distinct values over the range of the
 /// continuous valued input, and comparing the black box response with the expected/correct response.
 /// </summary>
-public sealed class FuncRegressionEvaluator : IPhenomeEvaluator<IBlackBox<double>>
+/// <typeparam name="TScalar">Black box input/output data type.</typeparam>
+public sealed class FuncRegressionEvaluator<TScalar> : IPhenomeEvaluator<IBlackBox<TScalar>>
+    where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
 {
-    readonly ParamSamplingInfo _paramSamplingInfo;
-    readonly double _gradientMseWeight;
-    readonly double _yMseWeight;
+    readonly ParamSamplingInfo<TScalar> _paramSamplingInfo;
+    readonly TScalar _gradientMseWeight;
+    readonly TScalar _yMseWeight;
 
     // Expected/correct response arrays.
-    readonly double[] _yArrTarget;
-    readonly double[] _gradientArrTarget;
+    readonly TScalar[] _yArrTarget;
+    readonly TScalar[] _gradientArrTarget;
 
     // Actual black box response arrays (reusable evaluator state).
-    readonly double[] _yArr;
-    readonly double[] _gradientArr;
+    readonly TScalar[] _yArr;
+    readonly TScalar[] _gradientArr;
 
-    readonly IBlackBoxProbe _blackBoxProbe;
+    readonly IBlackBoxProbe<TScalar> _blackBoxProbe;
 
     #region Constructors
 
@@ -40,23 +43,23 @@ public sealed class FuncRegressionEvaluator : IPhenomeEvaluator<IBlackBox<double
     /// <param name="gradientArrTarget">Array of target gradient values.</param>
     /// <param name="blackBoxProbe">Black box probe. For obtaining the y value response array from an instance of <see cref="IBlackBox{T}"/>.</param>
     internal FuncRegressionEvaluator(
-        ParamSamplingInfo paramSamplingInfo,
-        double gradientMseWeight,
-        double[] yArrTarget,
-        double[] gradientArrTarget,
-        IBlackBoxProbe blackBoxProbe)
+        ParamSamplingInfo<TScalar> paramSamplingInfo,
+        TScalar gradientMseWeight,
+        TScalar[] yArrTarget,
+        TScalar[] gradientArrTarget,
+        IBlackBoxProbe<TScalar> blackBoxProbe)
     {
         _paramSamplingInfo = paramSamplingInfo;
         _gradientMseWeight = gradientMseWeight;
-        _yMseWeight = 1.0 - gradientMseWeight;
+        _yMseWeight = TScalar.One - gradientMseWeight;
 
         _yArrTarget = yArrTarget;
         _gradientArrTarget = gradientArrTarget;
 
         // Alloc working arrays for receiving black box outputs.
         int sampleCount = _paramSamplingInfo.SampleResolution;
-        _yArr = new double[sampleCount];
-        _gradientArr = new double[sampleCount];
+        _yArr = new TScalar[sampleCount];
+        _gradientArr = new TScalar[sampleCount];
 
         _blackBoxProbe = blackBoxProbe;
     }
@@ -65,13 +68,16 @@ public sealed class FuncRegressionEvaluator : IPhenomeEvaluator<IBlackBox<double
 
     #region Public Methods
 
+    static readonly TScalar PointZeroTwo = TScalar.CreateChecked(0.02);
+    static readonly TScalar Twenty = TScalar.CreateChecked(20.0);
+
     /// <summary>
     /// Evaluate the provided black box against the function regression task,
     /// and return its fitness score.
     /// </summary>
     /// <param name="box">The black box to evaluate.</param>
     /// <returns>A new instance of <see cref="FitnessInfo"/>.</returns>
-    public FitnessInfo Evaluate(IBlackBox<double> box)
+    public FitnessInfo Evaluate(IBlackBox<TScalar> box)
     {
         // Probe the black box over the full range of the input parameter.
         _blackBoxProbe.Probe(box, _yArr);
@@ -83,26 +89,26 @@ public sealed class FuncRegressionEvaluator : IPhenomeEvaluator<IBlackBox<double
         // S-curve has. Arguably such networks should use such an S-curve like activation function rather than 'fixing'
         // the problem here.
         // TODO: Optimisation candidate. Vectorize the search for the non-finite bit pattern.
-        if(Array.Exists(_yArr, x => !double.IsFinite(x)))
+        if(Array.Exists(_yArr, x => !TScalar.IsFinite(x)))
             return FitnessInfo.DefaultFitnessInfo;
 
         // Calc gradients.
-        FuncRegressionUtils.CalcGradients(_paramSamplingInfo, _yArr, _gradientArr);
+        FuncRegressionUtils<TScalar>.CalcGradients(_paramSamplingInfo, _yArr, _gradientArr);
 
         // Calc y position mean squared error (MSE), and apply weighting.
-        double yMse = MathSpan.MeanSquaredDelta<double>(_yArr, _yArrTarget);
+        TScalar yMse = MathSpan.MeanSquaredDelta<TScalar>(_yArr, _yArrTarget);
         yMse *= _yMseWeight;
 
         // Calc gradient mean squared error.
-        double gradientMse = MathSpan.MeanSquaredDelta<double>(_gradientArr, _gradientArrTarget);
+        TScalar gradientMse = MathSpan.MeanSquaredDelta<TScalar>(_gradientArr, _gradientArrTarget);
         gradientMse *= _gradientMseWeight;
 
         // Calc fitness as the inverse of MSE (higher value is fitter).
         // Add a constant to avoid divide by zero, and to constrain the fitness range between bad and good solutions;
         // this allows the selection strategy to select solutions that are mediocre and therefore helps preserve diversity.
-        double fitness = 20.0 / (yMse + gradientMse + 0.02);
+        TScalar fitness = Twenty / (yMse + gradientMse + PointZeroTwo);
 
-        return new FitnessInfo(fitness);
+        return new FitnessInfo(double.CreateSaturating(fitness));
     }
 
     #endregion

--- a/src/SharpNeat.Tasks/FunctionRegression/IBlackBoxProbe.cs
+++ b/src/SharpNeat.Tasks/FunctionRegression/IBlackBoxProbe.cs
@@ -1,12 +1,15 @@
 ﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
+using System.Numerics;
 
 namespace SharpNeat.Tasks.FunctionRegression;
 
 /// <summary>
 /// For probing and recording the responses of instances of <see cref="IBlackBox{T}"/>.
 /// </summary>
-public interface IBlackBoxProbe
+/// <typeparam name="TScalar">Black box input/output data type.</typeparam>
+public interface IBlackBoxProbe<TScalar>
+    where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
 {
     // TODO: Convert responseArr to Span<double>
     /// <summary>
@@ -14,5 +17,5 @@ public interface IBlackBoxProbe
     /// </summary>
     /// <param name="box">The black box to probe.</param>
     /// <param name="responseArr">Response array.</param>
-    void Probe(IBlackBox<double> box, double[] responseArr);
+    void Probe(IBlackBox<TScalar> box, TScalar[] responseArr);
 }

--- a/src/SharpNeat.Tasks/FunctionRegression/ParamSamplingInfo.cs
+++ b/src/SharpNeat.Tasks/FunctionRegression/ParamSamplingInfo.cs
@@ -1,6 +1,7 @@
 ﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
 using System.Diagnostics;
+using System.Numerics;
 
 namespace SharpNeat.Tasks.FunctionRegression;
 
@@ -8,22 +9,23 @@ namespace SharpNeat.Tasks.FunctionRegression;
 /// Parameter sampling info.
 /// Describes the value range to sample, the number of samples within that range, and the increment between samples.
 /// </summary>
-public readonly struct ParamSamplingInfo
+public readonly struct ParamSamplingInfo<TScalar>
+    where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
 {
     /// <summary>
     /// Sample interval minimum.
     /// </summary>
-    public double Min { get; }
+    public TScalar Min { get; }
 
     /// <summary>
     /// Sample interval maximum.
     /// </summary>
-    public double Max { get; }
+    public TScalar Max { get; }
 
     /// <summary>
     /// Intra sample increment.
     /// </summary>
-    public double Incr { get; }
+    public TScalar Incr { get; }
 
     /// <summary>
     /// Sampling resolution, within the defined min-max interval.
@@ -33,12 +35,12 @@ public readonly struct ParamSamplingInfo
     /// <summary>
     /// X positions of the sample points.
     /// </summary>
-    public double[] XArr { get; }
+    public TScalar[] XArr { get; }
 
     /// <summary>
     /// X positions of the sample points in the neural net input space (i.e. scaled from 0 to 1).
     /// </summary>
-    public double[] XArrNetwork { get; }
+    public TScalar[] XArrNetwork { get; }
 
     /// <summary>
     /// Construct with the provided parameter sampling info.
@@ -46,19 +48,19 @@ public readonly struct ParamSamplingInfo
     /// <param name="min">Sample interval minimum.</param>
     /// <param name="max">Sample interval maximum.</param>
     /// <param name="resolution">Sampling resolution.</param>
-    public ParamSamplingInfo(double min, double max, int resolution)
+    public ParamSamplingInfo(TScalar min, TScalar max, int resolution)
     {
         Debug.Assert(resolution>=3, "Sample count must be >= 3");
         Min = min;
         Max = max;
-        double incr = Incr = (max-min) / (resolution - 1);
+        TScalar incr = Incr = (max-min) / TScalar.CreateChecked((resolution - 1));
         SampleResolution = resolution;
 
-        double incrNet = 1.0 / (resolution - 1);
-        double x = min;
-        double xNet = 0.0;
-        XArr = new double[resolution];
-        XArrNetwork = new double[resolution];
+        TScalar incrNet = TScalar.Zero / TScalar.CreateChecked(resolution - 1);
+        TScalar x = min;
+        TScalar xNet = TScalar.Zero;
+        XArr = new TScalar[resolution];
+        XArrNetwork = new TScalar[resolution];
 
         for(int i=0; i < resolution; i++, x += incr, xNet += incrNet)
         {

--- a/src/SharpNeat.Tasks/GenerativeFunctionRegression/GenerativeBlackBoxProbe.cs
+++ b/src/SharpNeat.Tasks/GenerativeFunctionRegression/GenerativeBlackBoxProbe.cs
@@ -1,6 +1,7 @@
 ﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
 using System.Diagnostics;
+using System.Numerics;
 using SharpNeat.Tasks.FunctionRegression;
 
 namespace SharpNeat.Tasks.GenerativeFunctionRegression;
@@ -8,11 +9,14 @@ namespace SharpNeat.Tasks.GenerativeFunctionRegression;
 /// <summary>
 /// For probing and recording the responses of instances of <see cref="IBlackBox{T}"/>.
 /// </summary>
-public sealed class GenerativeBlackBoxProbe : IBlackBoxProbe
+public sealed class GenerativeBlackBoxProbe<TScalar> : IBlackBoxProbe<TScalar>
+    where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
 {
+    static readonly TScalar Half = TScalar.CreateSaturating(0.5);
+
     readonly int _sampleCount;
-    readonly double _offset;
-    readonly double _scale;
+    readonly TScalar _offset;
+    readonly TScalar _scale;
 
     /// <summary>
     /// Construct a new instance.
@@ -20,7 +24,7 @@ public sealed class GenerativeBlackBoxProbe : IBlackBoxProbe
     /// <param name="sampleCount">The number of generative samples to take.</param>
     /// <param name="offset">Offset to apply to each black box output response.</param>
     /// <param name="scale">Scaling factor to apply to each black box output response.</param>
-    public GenerativeBlackBoxProbe(int sampleCount, double offset, double scale)
+    public GenerativeBlackBoxProbe(int sampleCount, TScalar offset, TScalar scale)
     {
         _sampleCount = sampleCount;
         _offset = offset;
@@ -28,7 +32,7 @@ public sealed class GenerativeBlackBoxProbe : IBlackBoxProbe
     }
 
     /// <inheritdoc/>
-    public void Probe(IBlackBox<double> box, double[] responseArr)
+    public void Probe(IBlackBox<TScalar> box, TScalar[] responseArr)
     {
         Debug.Assert(responseArr.Length == _sampleCount);
 
@@ -41,7 +45,7 @@ public sealed class GenerativeBlackBoxProbe : IBlackBoxProbe
 
         // Set bias input.
         // This will remain set for the lifetime of the below loops.
-        inputs[0] = 1.0;
+        inputs[0] = TScalar.One;
 
         // Perform some warm-up activations of the neural net.
         for(int i = 0; i < 3; i++)
@@ -58,7 +62,7 @@ public sealed class GenerativeBlackBoxProbe : IBlackBoxProbe
             // Get the black box's output value.
             // TODO: Review this scheme. This replicates the behaviour in SharpNEAT 2.x but not sure if it's ideal,
             // for one it depends on the output range of the neural net activation function in use.
-            responseArr[i] = ((outputs[0] - 0.5) * _scale) + _offset;
+            responseArr[i] = ((outputs[0] - Half) * _scale) + _offset;
         }
     }
 }

--- a/src/SharpNeat.Tasks/GenerativeFunctionRegression/GenerativeFnRegressionEvaluationScheme.cs
+++ b/src/SharpNeat.Tasks/GenerativeFunctionRegression/GenerativeFnRegressionEvaluationScheme.cs
@@ -1,5 +1,6 @@
 ﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
+using System.Numerics;
 using SharpNeat.Evaluation;
 using SharpNeat.Tasks.FunctionRegression;
 
@@ -8,16 +9,18 @@ namespace SharpNeat.Tasks.GenerativeFunctionRegression;
 /// <summary>
 /// Evaluation scheme for the function regression task.
 /// </summary>
-public sealed class GenerativeFnRegressionEvaluationScheme : IBlackBoxEvaluationScheme<double>
+/// <typeparam name="TScalar">Black box input/output data type.</typeparam>
+public sealed class GenerativeFnRegressionEvaluationScheme<TScalar> : IBlackBoxEvaluationScheme<TScalar>
+    where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
 {
-    readonly ParamSamplingInfo _paramSamplingInfo;
-    readonly double _gradientMseWeight;
+    readonly ParamSamplingInfo<TScalar> _paramSamplingInfo;
+    readonly TScalar _gradientMseWeight;
 
     // Expected/correct response arrays.
-    readonly double[] _yArrTarget;
-    readonly double[] _gradientArrTarget;
+    readonly TScalar[] _yArrTarget;
+    readonly TScalar[] _gradientArrTarget;
 
-    readonly IBlackBoxProbe _blackBoxProbe;
+    readonly IBlackBoxProbe<TScalar> _blackBoxProbe;
 
     #region Auto Properties [IBlackBoxEvaluationScheme]
 
@@ -50,21 +53,21 @@ public sealed class GenerativeFnRegressionEvaluationScheme : IBlackBoxEvaluation
     /// <param name="paramSamplingInfo">Sampling (defines the x range and sampling density).</param>
     /// <param name="gradientMseWeight">The fitness weighting to assign to the gradient mean squared error (MSE) score.</param>
     public GenerativeFnRegressionEvaluationScheme(
-        Func<double,double> fn,
-        ParamSamplingInfo paramSamplingInfo,
-        double gradientMseWeight)
+        Func<TScalar, TScalar> fn,
+        ParamSamplingInfo<TScalar> paramSamplingInfo,
+        TScalar gradientMseWeight)
     {
         _paramSamplingInfo = paramSamplingInfo;
         _gradientMseWeight = gradientMseWeight;
 
         // Alloc arrays.
         int sampleCount = _paramSamplingInfo.SampleResolution;
-        _yArrTarget = new double[sampleCount];
-        _gradientArrTarget = new double[sampleCount];
+        _yArrTarget = new TScalar[sampleCount];
+        _gradientArrTarget = new TScalar[sampleCount];
 
         // Calculate the target responses (the expected/correct responses).
-        FuncRegressionUtils.Probe(fn, paramSamplingInfo, _yArrTarget);
-        FuncRegressionUtils.CalcGradients(paramSamplingInfo, _yArrTarget, _gradientArrTarget);
+        FuncRegressionUtils<TScalar>.Probe(fn, paramSamplingInfo, _yArrTarget);
+        FuncRegressionUtils<TScalar>.CalcGradients(paramSamplingInfo, _yArrTarget, _gradientArrTarget);
 
         // Create blackbox probe.
         _blackBoxProbe = CreateBlackBoxProbe(fn, paramSamplingInfo);
@@ -75,9 +78,9 @@ public sealed class GenerativeFnRegressionEvaluationScheme : IBlackBoxEvaluation
     #region Public Methods
 
     /// <inheritdoc/>
-    public IPhenomeEvaluator<IBlackBox<double>> CreateEvaluator()
+    public IPhenomeEvaluator<IBlackBox<TScalar>> CreateEvaluator()
     {
-        return new FuncRegressionEvaluator(
+        return new FuncRegressionEvaluator<TScalar>(
             _paramSamplingInfo,
             _gradientMseWeight,
             _yArrTarget,
@@ -95,19 +98,19 @@ public sealed class GenerativeFnRegressionEvaluationScheme : IBlackBoxEvaluation
 
     #region Private Static Methods
 
-    private static GenerativeBlackBoxProbe CreateBlackBoxProbe(
-        Func<double,double> fn,
-        ParamSamplingInfo paramSamplingInfo)
+    private static GenerativeBlackBoxProbe<TScalar> CreateBlackBoxProbe(
+        Func<TScalar, TScalar> fn,
+        ParamSamplingInfo<TScalar> paramSamplingInfo)
     {
         // Determine the mid output value of the function (over the specified sample points) and a scaling factor
         // to apply the to neural network response for it to be able to recreate the function (because the neural net
         // output range is [0,1] when using the logistic function as the neuron activation function).
-        FuncRegressionUtils.CalcFunctionMidAndScale(
+        FuncRegressionUtils<TScalar>.CalcFunctionMidAndScale(
             fn, paramSamplingInfo,
-            out double mid,
-            out double scale);
+            out TScalar mid,
+            out TScalar scale);
 
-        return new GenerativeBlackBoxProbe(
+        return new GenerativeBlackBoxProbe<TScalar>(
             paramSamplingInfo.SampleResolution,
             mid, scale);
     }

--- a/src/SharpNeat.Tasks/GenerativeFunctionRegression/GenerativeFnRegressionExperimentFactory.cs
+++ b/src/SharpNeat.Tasks/GenerativeFunctionRegression/GenerativeFnRegressionExperimentFactory.cs
@@ -28,12 +28,12 @@ public sealed class GenerativeFnRegressionExperimentFactory : INeatExperimentFac
         ReadEvaluationSchemeConfig(
             experimentConfig,
             out Func<double, double> fn,
-            out ParamSamplingInfo paramSamplingInfo,
+            out ParamSamplingInfo<double> paramSamplingInfo,
             out double gradientMseWeight);
 
         // Create an evaluation scheme object for the generative sinewave task; using the evaluation scheme
         // config read from json.
-        var evalScheme = new GenerativeFnRegressionEvaluationScheme(fn, paramSamplingInfo, gradientMseWeight);
+        var evalScheme = new GenerativeFnRegressionEvaluationScheme<double>(fn, paramSamplingInfo, gradientMseWeight);
 
         // Create a NeatExperiment object with the evaluation scheme,
         // and assign some default settings (these can be overridden by config).
@@ -60,7 +60,7 @@ public sealed class GenerativeFnRegressionExperimentFactory : INeatExperimentFac
     private static void ReadEvaluationSchemeConfig(
         GenerativeFnRegressionExperimentConfig experimentConfig,
         out Func<double, double> fn,
-        out ParamSamplingInfo paramSamplingInfo,
+        out ParamSamplingInfo<double> paramSamplingInfo,
         out double gradientMseWeight)
     {
         // Get the customEvaluationSchemeConfig section.
@@ -72,7 +72,7 @@ public sealed class GenerativeFnRegressionExperimentFactory : INeatExperimentFac
         fn = FunctionFactory.GetFunction(functionId);
 
         // Read sample interval min and max, and sample resolution.
-        paramSamplingInfo = new ParamSamplingInfo(
+        paramSamplingInfo = new ParamSamplingInfo<double>(
             customConfig.SampleIntervalMin,
             customConfig.SampleIntervalMax,
             customConfig.SampleResolution);

--- a/src/SharpNeat.Tasks/PreyCapture/PreyCaptureEvaluationScheme.cs
+++ b/src/SharpNeat.Tasks/PreyCapture/PreyCaptureEvaluationScheme.cs
@@ -1,5 +1,6 @@
 ﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
+using System.Numerics;
 using SharpNeat.Evaluation;
 
 namespace SharpNeat.Tasks.PreyCapture;
@@ -7,7 +8,9 @@ namespace SharpNeat.Tasks.PreyCapture;
 /// <summary>
 /// Evaluation scheme for the prey capture task.
 /// </summary>
-public sealed class PreyCaptureEvaluationScheme : IBlackBoxEvaluationScheme<double>
+/// <typeparam name="TScalar">Black box input/output data type.</typeparam>
+public sealed class PreyCaptureEvaluationScheme<TScalar> : IBlackBoxEvaluationScheme<TScalar>
+    where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
 {
     readonly int _preyInitMoves;
     readonly float _preySpeed;
@@ -66,9 +69,9 @@ public sealed class PreyCaptureEvaluationScheme : IBlackBoxEvaluationScheme<doub
     #region Public Methods
 
     /// <inheritdoc/>
-    public IPhenomeEvaluator<IBlackBox<double>> CreateEvaluator()
+    public IPhenomeEvaluator<IBlackBox<TScalar>> CreateEvaluator()
     {
-        return new PreyCaptureEvaluator(
+        return new PreyCaptureEvaluator<TScalar>(
             _preyInitMoves,
             _preySpeed,
             _sensorRange,

--- a/src/SharpNeat.Tasks/PreyCapture/PreyCaptureEvaluator.cs
+++ b/src/SharpNeat.Tasks/PreyCapture/PreyCaptureEvaluator.cs
@@ -1,5 +1,6 @@
 ﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
+using System.Numerics;
 using SharpNeat.Evaluation;
 
 namespace SharpNeat.Tasks.PreyCapture;
@@ -7,9 +8,11 @@ namespace SharpNeat.Tasks.PreyCapture;
 /// <summary>
 /// Evaluator for the prey capture task.
 /// </summary>
-public sealed class PreyCaptureEvaluator : IPhenomeEvaluator<IBlackBox<double>>
+/// <typeparam name="TScalar">Black box input/output data type.</typeparam>
+public sealed class PreyCaptureEvaluator<TScalar> : IPhenomeEvaluator<IBlackBox<TScalar>>
+    where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
 {
-    readonly PreyCaptureWorld _world;
+    readonly PreyCaptureWorld<TScalar> _world;
     readonly int _trialsPerEvaluation;
 
     /// <summary>
@@ -28,7 +31,7 @@ public sealed class PreyCaptureEvaluator : IPhenomeEvaluator<IBlackBox<double>>
         int trialsPerEvaluation)
     {
         // Construct a re-usable instance of the prey capture world.
-        _world = new PreyCaptureWorld(preyInitMoves, preySpeed, sensorRange, maxTimesteps);
+        _world = new PreyCaptureWorld<TScalar>(preyInitMoves, preySpeed, sensorRange, maxTimesteps);
         _trialsPerEvaluation = trialsPerEvaluation;
     }
 
@@ -38,7 +41,7 @@ public sealed class PreyCaptureEvaluator : IPhenomeEvaluator<IBlackBox<double>>
     /// </summary>
     /// <param name="box">The black box to evaluate.</param>
     /// <returns>A new instance of <see cref="FitnessInfo"/>.</returns>
-    public FitnessInfo Evaluate(IBlackBox<double> box)
+    public FitnessInfo Evaluate(IBlackBox<TScalar> box)
     {
         // Perform multiple independent trials.
         int fitness = 0;

--- a/src/SharpNeat.Tasks/PreyCapture/PreyCaptureExperimentFactory.cs
+++ b/src/SharpNeat.Tasks/PreyCapture/PreyCaptureExperimentFactory.cs
@@ -25,7 +25,7 @@ public sealed class PreyCaptureExperimentFactory : INeatExperimentFactory
         PreyCaptureCustomConfig customConfig = experimentConfig.CustomEvaluationSchemeConfig;
 
         // Create an evaluation scheme object for the prey capture task.
-        var evalScheme = new PreyCaptureEvaluationScheme(
+        var evalScheme = new PreyCaptureEvaluationScheme<double>(
             customConfig.PreyInitMoves,
             customConfig.PreySpeed,
             customConfig.SensorRange,

--- a/src/SharpNeat.Tasks/Xor/XorEvaluationScheme.cs
+++ b/src/SharpNeat.Tasks/Xor/XorEvaluationScheme.cs
@@ -1,5 +1,6 @@
 ﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
+using System.Numerics;
 using SharpNeat.Evaluation;
 
 namespace SharpNeat.Tasks.Xor;
@@ -7,7 +8,9 @@ namespace SharpNeat.Tasks.Xor;
 /// <summary>
 /// Evaluation scheme for the logical XOR task.
 /// </summary>
-public sealed class XorEvaluationScheme : IBlackBoxEvaluationScheme<double>
+/// <typeparam name="TScalar">Black box input/output data type.</typeparam>
+public sealed class XorEvaluationScheme<TScalar> : IBlackBoxEvaluationScheme<TScalar>
+    where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
 {
     /// <inheritdoc/>
     public int InputCount => 3;
@@ -28,9 +31,9 @@ public sealed class XorEvaluationScheme : IBlackBoxEvaluationScheme<double>
     public bool EvaluatorsHaveState => false;
 
     /// <inheritdoc/>
-    public IPhenomeEvaluator<IBlackBox<double>> CreateEvaluator()
+    public IPhenomeEvaluator<IBlackBox<TScalar>> CreateEvaluator()
     {
-        return new XorEvaluator<double>();
+        return new XorEvaluator<TScalar>();
     }
 
     /// <inheritdoc/>

--- a/src/SharpNeat.Tasks/Xor/XorEvaluationScheme.cs
+++ b/src/SharpNeat.Tasks/Xor/XorEvaluationScheme.cs
@@ -30,7 +30,7 @@ public sealed class XorEvaluationScheme : IBlackBoxEvaluationScheme<double>
     /// <inheritdoc/>
     public IPhenomeEvaluator<IBlackBox<double>> CreateEvaluator()
     {
-        return new XorEvaluator();
+        return new XorEvaluator<double>();
     }
 
     /// <inheritdoc/>

--- a/src/SharpNeat.Tasks/Xor/XorEvaluator.cs
+++ b/src/SharpNeat.Tasks/Xor/XorEvaluator.cs
@@ -1,6 +1,5 @@
 ﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
-using System.Diagnostics;
 using System.Numerics;
 using SharpNeat.Evaluation;
 
@@ -60,10 +59,8 @@ public sealed class XorEvaluator<TScalar> : IPhenomeEvaluator<IBlackBox<TScalar>
         if(success)
             fitness += Ten;
 
-        return new FitnessInfo(double.CreateTruncating(fitness));
+        return new FitnessInfo(double.CreateSaturating(fitness));
     }
-
-    #region Private Static Methods
 
     private static TScalar Activate(
         IBlackBox<TScalar> box,
@@ -84,16 +81,13 @@ public sealed class XorEvaluator<TScalar> : IPhenomeEvaluator<IBlackBox<TScalar>
 
         // Read output signal.
         TScalar output = outputs[0];
-        Clip(ref output);
-        Debug.Assert(output >= TScalar.Zero, "Unexpected negative output.");
+        Clamp(ref output);
         return output;
     }
 
-    private static void Clip(ref TScalar x)
+    private static void Clamp(ref TScalar x)
     {
         if(x < TScalar.Zero) x = TScalar.Zero;
         else if(x > TScalar.One) x = TScalar.One;
     }
-
-    #endregion
 }

--- a/src/SharpNeat.Tasks/Xor/XorExperimentFactory.cs
+++ b/src/SharpNeat.Tasks/Xor/XorExperimentFactory.cs
@@ -22,7 +22,7 @@ public sealed class XorExperimentFactory : INeatExperimentFactory
         ExperimentConfig experimentConfig = JsonUtils.Deserialize<ExperimentConfig>(jsonConfigStream);
 
         // Create an evaluation scheme object for the XOR task.
-        var evalScheme = new XorEvaluationScheme();
+        var evalScheme = new XorEvaluationScheme<double>();
 
         // Create a NeatExperiment object with the evaluation scheme,
         // and assign some default settings (these can be overridden by config).

--- a/src/SharpNeat.Windows.App/SharpNeat.Windows.App.csproj
+++ b/src/SharpNeat.Windows.App/SharpNeat.Windows.App.csproj
@@ -34,6 +34,9 @@
     <None Update="config\experiments-config\binary-11-multiplexer.config.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="config\experiments-config\binary-3-multiplexer.config.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="config\experiments-config\binary-6-multiplexer.config.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -62,6 +65,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="config\experiments-descriptions\binary-11-multiplexer.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="config\experiments-descriptions\binary-3-multiplexer.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="config\experiments-descriptions\binary-6-multiplexer.txt">

--- a/src/SharpNeat.Windows.App/config/experiments-config/binary-3-multiplexer.config.json
+++ b/src/SharpNeat.Windows.App/config/experiments-config/binary-3-multiplexer.config.json
@@ -1,0 +1,35 @@
+﻿{
+  "name": "Binary 3-multiplexer",
+  "isAcyclic": true,
+  "activationFnName": "LeakyReLU",
+  "populationSize": 300,
+  "initialInterconnectionsProportion": 0.05,
+  "connectionWeightScale": 5.0,
+  "degreeOfParallelism": 4,
+  "enableHardwareAcceleratedNeuralNets": false,
+  "enableHardwareAcceleratedActivationFunctions": false,
+
+  "evolutionAlgorithm": {
+    "speciesCount": 10,
+    "elitismProportion": 0.2,
+    "selectionProportion": 0.2,
+    "offspringAsexualProportion": 0.5,
+    "offspringRecombinationProportion": 0.5,
+    "interspeciesMatingProportion": 0.01
+  },
+  "asexualReproduction": {
+    "connectionWeightMutationProbability": 0.94,
+    "addNodeMutationProbability": 0.01,
+    "addConnectionMutationProbability": 0.025,
+    "deleteConnectionMutationProbability": 0.025
+  },
+  "recombination": {
+    "secondaryParentGeneProbability": 0.1
+  },
+
+  "complexityRegulationStrategy": {
+    "strategyName": "relative",
+    "relativeComplexityCeiling": 10,
+    "minSimplifcationGenerations": 10
+  }
+}

--- a/src/SharpNeat.Windows.App/config/experiments-descriptions/binary-3-multiplexer.txt
+++ b/src/SharpNeat.Windows.App/config/experiments-descriptions/binary-3-multiplexer.txt
@@ -1,0 +1,13 @@
+﻿Binary 3-Multiplexer Task.
+
+A neural net has 3 inputs, one is a single address input, and two are data inputs. All of the inputs accept a binary value (zero or one).
+
+There is a single output.
+
+A binary address is presented to the address input, and this indicates which of the two data input values are to be selected for the output.
+
+Evaluation consists of exhaustively evaluating the network against each of the 8 (2^3) possible input combinations. For each evaluation, the output value must match the value being presented to the data input selected by the address inputs.
+
+An output less than 0.5 is considered a binary 0 response, and >=0.5 a binary 1. However, fitness at each evaluation is on a continuous linear scale, and these are summed across all evaluations to give a maximum possible fitness of 8.
+
+An additional fitness of 100 is added to the total if all 8 test cases are passed, giving a maximum possible fitness of 108.

--- a/src/SharpNeat.Windows.App/config/experiments.json
+++ b/src/SharpNeat.Windows.App/config/experiments.json
@@ -33,6 +33,22 @@
       }
     },
 
+    // === Binary 3-multiplexer ===
+    {
+      "name": "Binary 3-multiplexer",
+      "experimentFactory": {
+        "assemblyName": "SharpNeat.Tasks",
+        "typeName": "SharpNeat.Tasks.BinaryThreeMultiplexer.BinaryThreeMultiplexerExperimentFactory"
+      },
+      "configFile": "config/experiments-config/binary-3-multiplexer.config.json",
+      "descriptionFile": "config/experiments-descriptions/binary-3-multiplexer.txt",
+      // UI settings.
+      "experimentUiFactory": {
+        "assemblyName": "SharpNeat.Windows",
+        "typeName": "SharpNeat.Windows.Neat.NeatExperimentUiFactory"
+      }
+    },
+
     // === Binary 6-multiplexer ===
     {
       "name": "Binary 6-multiplexer",

--- a/src/SharpNeat/Evaluation/IBlackBoxEvaluationScheme.cs
+++ b/src/SharpNeat/Evaluation/IBlackBoxEvaluationScheme.cs
@@ -1,5 +1,7 @@
 ﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
+using System.Numerics;
+
 namespace SharpNeat.Evaluation;
 
 /// <summary>
@@ -8,7 +10,7 @@ namespace SharpNeat.Evaluation;
 /// </summary>
 /// <typeparam name="TScalar">Black box input/output data type.</typeparam>
 public interface IBlackBoxEvaluationScheme<TScalar> : IPhenomeEvaluationScheme<IBlackBox<TScalar>>
-    where TScalar : unmanaged
+    where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
 {
     /// <summary>
     /// The number of black box inputs expected/required by the black box evaluation scheme.

--- a/src/SharpNeat/Evaluation/IPhenomeEvaluator.cs
+++ b/src/SharpNeat/Evaluation/IPhenomeEvaluator.cs
@@ -5,8 +5,8 @@ namespace SharpNeat.Evaluation;
 /// <summary>
 /// Represents an evaluator of <typeparamref name="TPhenome"/> instances.
 /// </summary>
-/// <typeparam name="TPhenome">Phenome input/output signal data type.</typeparam>
-public interface IPhenomeEvaluator<TPhenome>
+/// <typeparam name="TPhenome">The phenome type.</typeparam>
+public interface IPhenomeEvaluator<in TPhenome>
 {
     /// <summary>
     /// Evaluate a single phenome and return its fitness score or scores.

--- a/src/SharpNeat/Experiments/INeatExperiment.cs
+++ b/src/SharpNeat/Experiments/INeatExperiment.cs
@@ -1,5 +1,6 @@
 ﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
+using System.Numerics;
 using SharpNeat.Neat.ComplexityRegulation;
 using SharpNeat.Neat.EvolutionAlgorithm;
 using SharpNeat.Neat.Reproduction.Asexual;
@@ -12,7 +13,7 @@ namespace SharpNeat.Experiments;
 /// </summary>
 /// <typeparam name="TScalar">Neural net connection weight and signal data type.</typeparam>
 public interface INeatExperiment<TScalar>
-    where TScalar : unmanaged
+    where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
 {
     /// <summary>
     /// Matches <see cref="INeatExperimentFactory.Id"/> from the experiment factory that created the current experiment instance.

--- a/src/SharpNeat/Experiments/NeatExperiment.cs
+++ b/src/SharpNeat/Experiments/NeatExperiment.cs
@@ -1,5 +1,6 @@
 ﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
+using System.Numerics;
 using SharpNeat.Neat.ComplexityRegulation;
 using SharpNeat.Neat.EvolutionAlgorithm;
 using SharpNeat.Neat.Reproduction.Asexual;
@@ -13,7 +14,7 @@ namespace SharpNeat.Experiments;
 /// </summary>
 /// <typeparam name="TScalar">Black box input/output data type.</typeparam>
 public class NeatExperiment<TScalar> : INeatExperiment<TScalar>
-    where TScalar : unmanaged
+    where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
 {
     /// <inheritdoc/>
     public string FactoryId { get; }

--- a/src/SharpNeat/Experiments/NeatExperimentExtensions.cs
+++ b/src/SharpNeat/Experiments/NeatExperimentExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
+using System.Numerics;
 using SharpNeat.Experiments.ConfigModels;
 using SharpNeat.Neat.ComplexityRegulation;
 using SharpNeat.NeuralNets;
@@ -21,7 +22,7 @@ public static class NeatExperimentExtensions
     public static void Configure<TScalar>(
         this INeatExperiment<TScalar> experiment,
         ExperimentConfig experimentConfig)
-        where TScalar : unmanaged
+        where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
     {
         experiment.Id = experimentConfig.Id ?? experiment.Id;
         experiment.Name = experimentConfig.Name ?? experiment.Name;
@@ -52,7 +53,7 @@ public static class NeatExperimentExtensions
     /// <returns>A new instance of <see cref="MetaNeatGenome{T}"/>.</returns>
     public static MetaNeatGenome<TScalar> CreateMetaNeatGenome<TScalar>(
         this INeatExperiment<TScalar> neatExperiment)
-        where TScalar : unmanaged
+        where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
     {
         // Resolve the configured activation function name to an activation function instance.
         var actFnFactory = new DefaultActivationFunctionFactory<TScalar>(
@@ -77,7 +78,7 @@ public static class NeatExperimentExtensions
     private static void ApplyConfiguration<TScalar>(
         INeatExperiment<TScalar> experiment,
         ComplexityRegulationStrategyConfig? config)
-        where TScalar : unmanaged
+        where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
     {
         if(config is null)
             return;

--- a/src/SharpNeat/IBlackBox.cs
+++ b/src/SharpNeat/IBlackBox.cs
@@ -1,5 +1,7 @@
 // This file is part of SharpNEAT; Copyright Colin D. Green.
 // See LICENSE.txt for details.
+using System.Numerics;
+
 namespace SharpNeat;
 
 /// <summary>
@@ -13,7 +15,7 @@ namespace SharpNeat;
 /// </summary>
 /// <typeparam name="TScalar">Black box input/output data type.</typeparam>
 public interface IBlackBox<TScalar> : IDisposable
-    where TScalar : unmanaged
+    where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
 {
     /// <summary>
     /// Gets a memory segment that represents a vector of input values.

--- a/src/SharpNeat/Neat/EvolutionAlgorithm/NeatEvolutionAlgorithmFactory.cs
+++ b/src/SharpNeat/Neat/EvolutionAlgorithm/NeatEvolutionAlgorithmFactory.cs
@@ -144,7 +144,7 @@ public static class NeatEvolutionAlgorithmFactory
     private static void ValidateCompatible<TScalar>(
         INeatExperiment<TScalar> neatExperiment,
         MetaNeatGenome<TScalar> metaNeatGenome)
-        where TScalar : unmanaged
+        where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
     {
         // Confirm that neatExperiment and metaNeatGenome are compatible with each other.
         if (neatExperiment.EvaluationScheme.InputCount != metaNeatGenome.InputNodeCount)

--- a/src/SharpNeat/Neat/Genome/Decoders/NeatGenomeDecoderFactory.cs
+++ b/src/SharpNeat/Neat/Genome/Decoders/NeatGenomeDecoderFactory.cs
@@ -21,7 +21,7 @@ public static class NeatGenomeDecoderFactory
     public static IGenomeDecoder<NeatGenome<TScalar>, IBlackBox<TScalar>> CreateGenomeDecoder<TScalar>(
         bool isAcyclic,
         bool enableHardwareAcceleration = false)
-        where TScalar : unmanaged
+        where TScalar : unmanaged, IBinaryFloatingPointIeee754<TScalar>
     {
         Type scalarType = typeof(TScalar);
 

--- a/src/Tests/SharpNeat.Tasks.Tests/BinaryThreeMultiplexerTests.cs
+++ b/src/Tests/SharpNeat.Tasks.Tests/BinaryThreeMultiplexerTests.cs
@@ -24,7 +24,7 @@ public class BinaryThreeMultiplexerTests
             netFileModel, enableHardwareAcceleration, enableHardwareAcceleration);
 
         // Evaluate the neural net.
-        var evaluator = new BinaryThreeMultiplexerEvaluator();
+        var evaluator = new BinaryThreeMultiplexerEvaluator<double>();
 
         // Confirm the expected fitness (to a limited amount of precision to allow for small variations of floating point
         // results that can occur as a result of platform/environmental variations).

--- a/src/Tests/SharpNeat.Tasks.Tests/FunctionRegression/FuncRegressionUtilsTests.cs
+++ b/src/Tests/SharpNeat.Tasks.Tests/FunctionRegression/FuncRegressionUtilsTests.cs
@@ -8,13 +8,13 @@ public class FuncRegressionUtilsTests
     public void CalcGradients()
     {
         const int sampleCount = 100;
-        ParamSamplingInfo psi = new(0, 2 * Math.PI, sampleCount);
+        ParamSamplingInfo<double> psi = new(0, 2 * Math.PI, sampleCount);
         double[] yArr = new double[sampleCount];
-        FuncRegressionUtils.Probe((x) => Math.Sin(x), psi, yArr);
+        FuncRegressionUtils<double>.Probe((x) => Math.Sin(x), psi, yArr);
 
         // Calc gradients.
         double[] gradientArr = new double[sampleCount];
-        FuncRegressionUtils.CalcGradients(psi, yArr, gradientArr);
+        FuncRegressionUtils<double>.CalcGradients(psi, yArr, gradientArr);
 
         // Calc expected gradients (using simple non-vectorized logic).
         double[] gradientArrExpected = new double[sampleCount];
@@ -27,7 +27,7 @@ public class FuncRegressionUtilsTests
     #region Private Static Methods
 
     private static void CalcGradients_IndependentImpl(
-        ParamSamplingInfo paramSamplingInfo,
+        ParamSamplingInfo<double> paramSamplingInfo,
         double[] yArr,
         double[] gradientArr)
     {

--- a/src/Tests/SharpNeat.Tasks.Tests/PreyCapture/PreyCaptureWorldTests.cs
+++ b/src/Tests/SharpNeat.Tasks.Tests/PreyCapture/PreyCaptureWorldTests.cs
@@ -8,7 +8,7 @@ public class PreyCaptureWorldTests
     [Fact]
     public void MoveAgent()
     {
-        var world = new PreyCaptureWorld(4, 1f, 4f, 100);
+        var world = new PreyCaptureWorld<double>(4, 1f, 4f, 100);
         using var agent = new MockPreyCaptureAgent();
 
         // Agent moving north test.
@@ -65,13 +65,13 @@ public class PreyCaptureWorldTests
     {
         // Use reflection to extract private static fields from the PreyCaptureWorld class; this is not ideal, but preferable
         // to making fields public that have no reason to be other than for unit testing.
-        FieldInfo gridSizeFieldInfo = typeof(PreyCaptureWorld).GetField("__gridSize", BindingFlags.Static | BindingFlags.NonPublic);
+        FieldInfo gridSizeFieldInfo = typeof(PreyCaptureWorld<double>).GetField("__gridSize", BindingFlags.Static | BindingFlags.NonPublic);
         int gridSize = (int)gridSizeFieldInfo.GetValue(null);
 
-        FieldInfo atan2LookupOffsetFieldInfo = typeof(PreyCaptureWorld).GetField("__atan2LookupOffset", BindingFlags.Static | BindingFlags.NonPublic);
+        FieldInfo atan2LookupOffsetFieldInfo = typeof(PreyCaptureWorld<double>).GetField("__atan2LookupOffset", BindingFlags.Static | BindingFlags.NonPublic);
         int atan2LookupOffset = (int)atan2LookupOffsetFieldInfo.GetValue(null);
 
-        FieldInfo atan2LookupFieldInfo = typeof(PreyCaptureWorld).GetField("__atan2Lookup", BindingFlags.Static | BindingFlags.NonPublic);
+        FieldInfo atan2LookupFieldInfo = typeof(PreyCaptureWorld<double>).GetField("__atan2Lookup", BindingFlags.Static | BindingFlags.NonPublic);
         float[,] atan2Lookup = (float[,])atan2LookupFieldInfo.GetValue(null);
 
 
@@ -90,7 +90,7 @@ public class PreyCaptureWorldTests
     {
         // Use reflection to call the CartesianToPolar() method from the PreyCaptureWorld class; this is not ideal, but preferable
         // to making methods internal or public that have no reason to be other than for unit testing.
-        MethodInfo methodInfo = typeof(PreyCaptureWorld).GetMethod("AngleDelta", BindingFlags.Static | BindingFlags.NonPublic);
+        MethodInfo methodInfo = typeof(PreyCaptureWorld<double>).GetMethod("AngleDelta", BindingFlags.Static | BindingFlags.NonPublic);
 
         // Define a local function that calls on the PreyCaptureWorld.AngleDelta() via reflection.
         float angleDelta(float a, float b)
@@ -151,7 +151,7 @@ public class PreyCaptureWorldTests
     {
         // Use reflection to call the CartesianToPolar() method from the PreyCaptureWorld class; this is not ideal, but preferable
         // to making methods internal or public that have no reason to be other than for unit testing.
-        MethodInfo methodInfo = typeof(PreyCaptureWorld).GetMethod("CartesianToPolar", BindingFlags.Static | BindingFlags.NonPublic);
+        MethodInfo methodInfo = typeof(PreyCaptureWorld<double>).GetMethod("CartesianToPolar", BindingFlags.Static | BindingFlags.NonPublic);
 
         // Define a local function that calls on the PreyCaptureWorld.Exp() via reflection.
         void cartesianToPolar(Int32Point p, out int radiusSqr, out float azimuth)
@@ -210,7 +210,7 @@ public class PreyCaptureWorldTests
     {
         // Use reflection to call the Exp() method from the PreyCaptureWorld class; this is not ideal, but preferable
         // to making methods internal or public that have no reason to be other than for unit testing.
-        MethodInfo expMethodInfo = typeof(PreyCaptureWorld).GetMethod("Exp", BindingFlags.Static | BindingFlags.NonPublic);
+        MethodInfo expMethodInfo = typeof(PreyCaptureWorld<double>).GetMethod("Exp", BindingFlags.Static | BindingFlags.NonPublic);
 
         // Define a local function that calls on the PreyCaptureWorld.Exp() via reflection.
         float expApprox(float x)


### PR DESCRIPTION
This PR makes all of the IBlackBoxEvaluationScheme implementations generic w.r.t to the data type used for the IBlackBox inputs and outputs.

This is a step towards broader support for running experiments with smaller data types such as float and half, instead of double precision floats.

Some of the tasks provide separate implementations of `IPhenomeEvaluator` for float and double (and will throw an exception for any other type) in order to maintain optimal performance. Other tasks are fully generic, where the performance impact is minimal in doign so, or for toy tasks that don't need to be performant (e.g. logical XOR).